### PR TITLE
Don't create a new err2 variable for subsequent errors

### DIFF
--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -354,9 +354,9 @@ func (e *Exporter) getRedundancySemp1(ch chan<- prometheus.Metric) (ok float64) 
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
 	var target Data
-	err2 := decoder.Decode(&target)
-	if err2 != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml RedundancySemp1", "err", err2)
+	err = decoder.Decode(&target)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't decode Xml RedundancySemp1", "err", err)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
@@ -409,9 +409,9 @@ func (e *Exporter) getSpoolSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
 	var target Data
-	err2 := decoder.Decode(&target)
-	if err2 != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml", "err", err2)
+	err = decoder.Decode(&target)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't decode Xml", "err", err)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
@@ -470,9 +470,9 @@ func (e *Exporter) getHealthSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
 	var target Data
-	err2 := decoder.Decode(&target)
-	if err2 != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml HealthSemp1", "err", err2)
+	err = decoder.Decode(&target)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't decode Xml HealthSemp1", "err", err)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
@@ -545,9 +545,9 @@ func (e *Exporter) getVpnSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
 	var target Data
-	err2 := decoder.Decode(&target)
-	if err2 != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml VpnSemp1", "err", err2)
+	err = decoder.Decode(&target)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't decode Xml VpnSemp1", "err", err)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
@@ -637,9 +637,9 @@ func (e *Exporter) getClientSemp1(ch chan<- prometheus.Metric) (ok float64) {
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
 		var target Data
-		err2 := decoder.Decode(&target)
-		if err2 != nil {
-			level.Error(e.logger).Log("msg", "Can't decode ClientSemp1", "err", err2)
+		err = decoder.Decode(&target)
+		if err != nil {
+			level.Error(e.logger).Log("msg", "Can't decode ClientSemp1", "err", err)
 			return 0
 		}
 		if target.ExecuteResult.Result != "ok" {
@@ -718,9 +718,9 @@ func (e *Exporter) getQueueSemp1(ch chan<- prometheus.Metric) (ok float64) {
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
 		var target Data
-		err2 := decoder.Decode(&target)
-		if err2 != nil {
-			level.Error(e.logger).Log("msg", "Can't decode QueueSemp1", "err", err2)
+		err = decoder.Decode(&target)
+		if err != nil {
+			level.Error(e.logger).Log("msg", "Can't decode QueueSemp1", "err", err)
 			return 0
 		}
 		if target.ExecuteResult.Result != "ok" {
@@ -791,9 +791,9 @@ func (e *Exporter) getQueueRatesSemp1(ch chan<- prometheus.Metric) (ok float64) 
 		defer body.Close()
 		decoder := xml.NewDecoder(body)
 		var target Data
-		err2 := decoder.Decode(&target)
-		if err2 != nil {
-			level.Error(e.logger).Log("msg", "Can't decode QueueRatesSemp1", "err", err2)
+		err = decoder.Decode(&target)
+		if err != nil {
+			level.Error(e.logger).Log("msg", "Can't decode QueueRatesSemp1", "err", err)
 			return 0
 		}
 		if target.ExecuteResult.Result != "ok" {


### PR DESCRIPTION
It's not common in Go to create a new error variable for multiple
subsequent operations that can fail (unless you need to handle multiple
errors at the same time).

Signed-off-by: Julius Volz <julius.volz@gmail.com>