### PR TITLE
Additional Metrics on Bridge monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,17 @@ It is currently only tested against PubSub+ software brokers (VMRs), not applian
 
 The exporter is written in go, based on the Solace Legacy SEMP protocol.<br/>
 It implements the following endpoints:<br/>
-<pre><code>http://&lt;host&gt;:&lt;port&gt;/             Document page showing list of endpoints
-http://&lt;host&gt;:&lt;port&gt;/metrics      Golang and standard Prometheus metrics
-http://&lt;host&gt;:&lt;port&gt;/solace-std   Solace metrics for System and VPN levels
-http://&lt;host&gt;:&lt;port&gt;/solace-det   Solace metrics for Messaging Clients and Queues</code></pre>
+<pre><code>http://&lt;host&gt;:&lt;port&gt;/         Document page showing list of endpoints
+http://&lt;host&gt;:&lt;port&gt;/metrics             Golang and standard Prometheus metrics
+http://&lt;host&gt;:&lt;port&gt;/solace-std          Solace metrics for System and VPN levels
+http://&lt;host&gt;:&lt;port&gt;/solace-det          Solace metrics for Messaging Clients and Queues
+http://&lt;host&gt;:&lt;port&gt;/solace-broker-std   Solace Broker only Standard Metrics (System)
+http://&lt;host&gt;:&lt;port&gt;/solace-broker-stats Solace Broker only Statistics Metrics (System)
+http://&lt;host&gt;:&lt;port&gt;/solace-broker-det   Solace Broker only Detailed Metrics (System)
+http://&lt;host&gt;:&lt;port&gt;/solace-vpn-std      Solace Vpn only Standard Metrics (VPN), available to non-global access right admins
+http://&lt;host&gt;:&lt;port&gt;/solace-vpn-stats    Solace Vpn only Statistics Metrics (VPN), available to non-global access right admins
+http://&lt;host&gt;:&lt;port&gt;/solace-vpn-det      Solace Vpn only Detailed Metrics (VPN), available to non-global access right admins
+</code></pre>
 The [registered](https://github.com/prometheus/prometheus/wiki/Default-port-allocations) default port for Solace is 9628<br/>
 
 ## Usage

--- a/grafana/solace-bridge-dashboard.json
+++ b/grafana/solace-bridge-dashboard.json
@@ -1,0 +1,1439 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:3179",
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1593432007433,
+  "links": [
+    {
+      "$$hashKey": "object:393",
+      "icon": "external link",
+      "includeVars": true,
+      "tags": [
+        "solace"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "$$hashKey": "object:694",
+      "icon": "external link",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Help: Bridge",
+      "tooltip": "Help: Bridge Monitoring Dashboard",
+      "type": "link",
+      "url": "https://confluence.sbb.ch/display/MOPRO/Solace+Monitoring+Dashboard%3A+Bridge"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Operational State",
+      "type": "row"
+    },
+    {
+      "cards": {
+        "cardHSpacing": 2,
+        "cardMinWidth": 5,
+        "cardRound": null,
+        "cardVSpacing": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGnYlRd",
+        "defaultColor": "#757575",
+        "exponent": 0.5,
+        "mode": "discrete",
+        "thresholds": [
+          {
+            "$$hashKey": "object:3298",
+            "color": "#37872D",
+            "tooltip": "up",
+            "value": "0"
+          },
+          {
+            "$$hashKey": "object:3302",
+            "color": "#C4162A",
+            "tooltip": "down",
+            "value": "1"
+          }
+        ]
+      },
+      "data": {
+        "decimals": null,
+        "unitFormat": "short"
+      },
+      "datasource": "Prometheus",
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "highlightCards": true,
+      "id": 2,
+      "legend": {
+        "show": true
+      },
+      "links": [
+        {
+          "title": "Bridges Overview",
+          "url": "/d/0zeRtZmGk/solace-bridges?orgId=1&var-instance=${instance}"
+        }
+      ],
+      "nullPointMode": "as empty",
+      "seriesFilterIndex": -1,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_admin_state{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")",
+          "interval": "",
+          "legendFormat": " ",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Admin State",
+      "tooltip": {
+        "show": true
+      },
+      "transparent": true,
+      "type": "flant-statusmap-panel",
+      "urls": [
+        {
+          "base_url": "",
+          "extraSeries": {
+            "index": -1
+          },
+          "forcelowercase": true,
+          "icon_fa": "external-link",
+          "label": "",
+          "tooltip": "",
+          "useExtraSeries": false,
+          "useseriesname": true
+        }
+      ],
+      "useMax": true,
+      "usingUrl": false,
+      "xAxis": {
+        "labelFormat": "%a %m/%d",
+        "minBucketWidthToShowWeekends": 4,
+        "show": true,
+        "showCrosshair": true,
+        "showWeekends": true
+      },
+      "yAxis": {
+        "maxWidth": -1,
+        "minWidth": -1,
+        "show": true,
+        "showCrosshair": false
+      },
+      "yAxisSort": "metrics"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "decimals": 2,
+      "format": "s",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 0,
+        "y": 4
+      },
+      "id": 8,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "$$hashKey": "object:7865",
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "$$hashKey": "object:7866",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "pluginVersion": "6.7.2",
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_connection_uptime_in_seconds{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "uptime",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Connection up time",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "$$hashKey": "object:7868",
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "description": "which side is initiating the bridge connection",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 5,
+        "y": 4
+      },
+      "id": 10,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "$$hashKey": "object:8069",
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "$$hashKey": "object:8070",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_connection_establisher{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Connection Establisher",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Connection Establisher",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "$$hashKey": "object:8072",
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        },
+        {
+          "$$hashKey": "object:8108",
+          "op": "=",
+          "text": "n/a",
+          "value": "-1"
+        },
+        {
+          "$$hashKey": "object:8110",
+          "op": "=",
+          "text": "NotApplicable",
+          "value": "0"
+        },
+        {
+          "$$hashKey": "object:8112",
+          "op": "=",
+          "text": "auto",
+          "value": "1"
+        },
+        {
+          "$$hashKey": "object:8114",
+          "op": "=",
+          "text": "Local",
+          "value": "2"
+        },
+        {
+          "$$hashKey": "object:8116",
+          "op": "=",
+          "text": "Remote",
+          "value": "3"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "description": "connection setup when connecting to redundancy pair",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 10,
+        "y": 4
+      },
+      "id": 11,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "$$hashKey": "object:8069",
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "$$hashKey": "object:8070",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_redundancy{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Connection Establisher",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Redundancy Connection",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "$$hashKey": "object:8072",
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        },
+        {
+          "$$hashKey": "object:8108",
+          "op": "=",
+          "text": "n/a",
+          "value": "-1"
+        },
+        {
+          "$$hashKey": "object:8110",
+          "op": "=",
+          "text": "NotApplicable",
+          "value": "0"
+        },
+        {
+          "$$hashKey": "object:8112",
+          "op": "=",
+          "text": "auto",
+          "value": "1"
+        },
+        {
+          "$$hashKey": "object:8114",
+          "op": "=",
+          "text": "primary",
+          "value": "2"
+        },
+        {
+          "$$hashKey": "object:8116",
+          "op": "=",
+          "text": "backup",
+          "value": "3"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "Prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 9,
+        "x": 15,
+        "y": 4
+      },
+      "id": 19,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "$$hashKey": "object:8069",
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "$$hashKey": "object:8070",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_inbound_operational_failure_reason{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Connection Establisher",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "18,18",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Inbound Operational Failure Reason",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "$$hashKey": "object:8072",
+          "op": "=",
+          "text": "Bridge disabled",
+          "value": "0"
+        },
+        {
+          "$$hashKey": "object:8108",
+          "op": "=",
+          "text": "No remote message-vpns configured",
+          "value": "1"
+        },
+        {
+          "$$hashKey": "object:8110",
+          "op": "=",
+          "text": "SMF service is disabled",
+          "value": "2"
+        },
+        {
+          "$$hashKey": "object:8112",
+          "op": "=",
+          "text": "Msg Backbone is disabled",
+          "value": "3"
+        },
+        {
+          "$$hashKey": "object:8114",
+          "op": "=",
+          "text": "Local message-vpn is disabled",
+          "value": "4"
+        },
+        {
+          "$$hashKey": "object:8116",
+          "op": "=",
+          "text": "Active-Standby Role Mismatch",
+          "value": "5"
+        },
+        {
+          "$$hashKey": "object:1235",
+          "op": "=",
+          "text": "Invalid Active-Standby Role",
+          "value": "6"
+        },
+        {
+          "$$hashKey": "object:1237",
+          "op": "=",
+          "text": "Redundancy Disabled",
+          "value": "7"
+        },
+        {
+          "$$hashKey": "object:1239",
+          "op": "=",
+          "text": "Not active",
+          "value": "8"
+        },
+        {
+          "$$hashKey": "object:1241",
+          "op": "=",
+          "text": "Replication standby",
+          "value": "9"
+        },
+        {
+          "$$hashKey": "object:1243",
+          "op": "=",
+          "text": "Remote message-vpns disabled",
+          "value": "10"
+        },
+        {
+          "$$hashKey": "object:1245",
+          "op": "=",
+          "text": "Enforce-trusted-common-name but empty trust-common-name list",
+          "value": "11"
+        },
+        {
+          "$$hashKey": "object:1247",
+          "op": "=",
+          "text": "SSL transport used but cipher-suite list is empty",
+          "value": "12"
+        },
+        {
+          "$$hashKey": "object:1249",
+          "op": "=",
+          "text": "Authentication Scheme is Client-Certificate but no certificate is configured",
+          "value": "13"
+        },
+        {
+          "$$hashKey": "object:1251",
+          "op": "=",
+          "text": "Client-Certificate Authentication Scheme used but not all Remote Message VPNs use SSL",
+          "value": "14"
+        },
+        {
+          "$$hashKey": "object:1253",
+          "op": "=",
+          "text": "Basic Authentication Scheme used but Basic Client Username not configured",
+          "value": "15"
+        },
+        {
+          "$$hashKey": "object:1255",
+          "op": "=",
+          "text": "Cluster Down",
+          "value": "16"
+        },
+        {
+          "$$hashKey": "object:1257",
+          "op": "=",
+          "text": "Cluster Link Down",
+          "value": "17"
+        },
+        {
+          "$$hashKey": "object:1259",
+          "op": "=",
+          "text": "(no failure)",
+          "value": "18"
+        },
+        {
+          "$$hashKey": "object:1261",
+          "op": "=",
+          "text": "unknown",
+          "value": "-1"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cards": {
+        "cardHSpacing": 2,
+        "cardMinWidth": 5,
+        "cardRound": null,
+        "cardVSpacing": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGnYlRd",
+        "defaultColor": "#757575",
+        "exponent": 0.5,
+        "mode": "discrete",
+        "thresholds": [
+          {
+            "$$hashKey": "object:7612",
+            "color": "#C0D8FF",
+            "tooltip": "Init",
+            "value": "0"
+          },
+          {
+            "$$hashKey": "object:7616",
+            "color": "#C4162A",
+            "tooltip": "Shutdown",
+            "value": "1"
+          },
+          {
+            "$$hashKey": "object:7620",
+            "color": "#8AB8FF",
+            "tooltip": "NoShutdown",
+            "value": "2"
+          },
+          {
+            "$$hashKey": "object:7624",
+            "color": "#3274D9",
+            "tooltip": "Prepare",
+            "value": "3"
+          },
+          {
+            "$$hashKey": "object:7628",
+            "color": "#1F60C4",
+            "tooltip": "WaitToConnect",
+            "value": "4"
+          },
+          {
+            "$$hashKey": "object:7632",
+            "color": "#FADE2A",
+            "tooltip": "FetchingDNS",
+            "value": "5"
+          },
+          {
+            "$$hashKey": "object:7636",
+            "color": "#FADE2A",
+            "tooltip": "NotReady",
+            "value": "6"
+          },
+          {
+            "$$hashKey": "object:7640",
+            "color": "#FADE2A",
+            "tooltip": "Connecting",
+            "value": "7"
+          },
+          {
+            "$$hashKey": "object:7644",
+            "color": "#FADE2A",
+            "tooltip": "Handshaking",
+            "value": "8"
+          },
+          {
+            "$$hashKey": "object:7648",
+            "color": "#FADE2A",
+            "tooltip": "WaitNext",
+            "value": "9"
+          },
+          {
+            "$$hashKey": "object:7652",
+            "color": "#FADE2A",
+            "tooltip": "WaitReuse",
+            "value": "10"
+          },
+          {
+            "$$hashKey": "object:7656",
+            "color": "#FADE2A",
+            "tooltip": "WaitBridgeVersionMismatch",
+            "value": "11"
+          },
+          {
+            "$$hashKey": "object:720",
+            "color": "#FADE2A",
+            "tooltip": "WaitCleanup",
+            "value": "12"
+          },
+          {
+            "$$hashKey": "object:727",
+            "color": "#96D98D",
+            "tooltip": "Ready",
+            "value": "13"
+          },
+          {
+            "$$hashKey": "object:734",
+            "color": "#56A64B",
+            "tooltip": "Subscribing",
+            "value": "14"
+          },
+          {
+            "$$hashKey": "object:741",
+            "color": "#37872D",
+            "tooltip": "InSync",
+            "value": "15"
+          },
+          {
+            "$$hashKey": "object:748",
+            "color": "#B877D9",
+            "tooltip": "NotApplicable",
+            "value": "16"
+          },
+          {
+            "$$hashKey": "object:755",
+            "color": "#F2495C",
+            "tooltip": "Invalid",
+            "value": "17"
+          },
+          {
+            "$$hashKey": "object:786",
+            "color": "#C4162A",
+            "tooltip": "unknown",
+            "value": "-1"
+          }
+        ]
+      },
+      "data": {
+        "decimals": null,
+        "unitFormat": "short"
+      },
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "highlightCards": true,
+      "id": 6,
+      "legend": {
+        "show": true
+      },
+      "nullPointMode": "as empty",
+      "seriesFilterIndex": -1,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_inbound_operational_state{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")\r\n",
+          "interval": "",
+          "legendFormat": "Inbound",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(solace_bridge_outbound_operational_state{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")\r\n",
+          "interval": "",
+          "legendFormat": "Outbound",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "tooltip": {
+        "show": true
+      },
+      "transparent": true,
+      "type": "flant-statusmap-panel",
+      "urls": [
+        {
+          "base_url": "",
+          "extraSeries": {
+            "index": -1
+          },
+          "forcelowercase": true,
+          "icon_fa": "external-link",
+          "label": "",
+          "tooltip": "",
+          "useExtraSeries": false,
+          "useseriesname": true
+        }
+      ],
+      "useMax": true,
+      "usingUrl": false,
+      "xAxis": {
+        "labelFormat": "%a %m/%d",
+        "minBucketWidthToShowWeekends": 4,
+        "show": true,
+        "showCrosshair": true,
+        "showWeekends": true
+      },
+      "yAxis": {
+        "maxWidth": -1,
+        "minWidth": -1,
+        "show": true,
+        "showCrosshair": false
+      },
+      "yAxisSort": "metrics"
+    },
+    {
+      "cards": {
+        "cardHSpacing": 2,
+        "cardMinWidth": 5,
+        "cardRound": null,
+        "cardVSpacing": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGnYlRd",
+        "defaultColor": "#757575",
+        "exponent": 0.5,
+        "mode": "discrete",
+        "thresholds": [
+          {
+            "$$hashKey": "object:7612",
+            "color": "#B877D9",
+            "tooltip": "NotApplicable",
+            "value": "0"
+          },
+          {
+            "$$hashKey": "object:7616",
+            "color": "#37872D",
+            "tooltip": "Bound",
+            "value": "1"
+          },
+          {
+            "$$hashKey": "object:7620",
+            "color": "#FADE2A",
+            "tooltip": "Unbound",
+            "value": "2"
+          },
+          {
+            "$$hashKey": "object:786",
+            "color": "#F2495C",
+            "tooltip": "unknown",
+            "value": "-1"
+          }
+        ]
+      },
+      "data": {
+        "decimals": null,
+        "unitFormat": "short"
+      },
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "highlightCards": true,
+      "id": 18,
+      "legend": {
+        "show": true
+      },
+      "nullPointMode": "as empty",
+      "seriesFilterIndex": -1,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_queue_operational_state{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")\r\n",
+          "interval": "",
+          "legendFormat": "Queue",
+          "refId": "C"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "tooltip": {
+        "show": true
+      },
+      "type": "flant-statusmap-panel",
+      "urls": [
+        {
+          "base_url": "",
+          "extraSeries": {
+            "index": -1
+          },
+          "forcelowercase": true,
+          "icon_fa": "external-link",
+          "label": "",
+          "tooltip": "",
+          "useExtraSeries": false,
+          "useseriesname": true
+        }
+      ],
+      "useMax": true,
+      "usingUrl": false,
+      "xAxis": {
+        "labelFormat": "%a %m/%d",
+        "minBucketWidthToShowWeekends": 4,
+        "show": true,
+        "showCrosshair": true,
+        "showWeekends": true
+      },
+      "yAxis": {
+        "maxWidth": -1,
+        "minWidth": -1,
+        "show": true,
+        "showCrosshair": false
+      },
+      "yAxisSort": "metrics"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Performance",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "decimals": null,
+      "description": "Number of subscribers and percentage slow subscribers",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "hiddenSeries": false,
+      "id": 15,
+      "interval": "",
+      "legend": {
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:14552",
+          "alias": "Slow",
+          "yaxis": 2
+        },
+        {
+          "alias": "Slow Subscribers",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_client_num_subscriptions{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")\r",
+          "interval": "",
+          "legendFormat": "Clients Subscribing",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(solace_bridge_client_slow_subscriber{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")\r",
+          "interval": "",
+          "legendFormat": "Slow Subscribers",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subscribers: Count / Slow",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:8295",
+          "decimals": 0,
+          "format": "short",
+          "label": "Clients",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:8296",
+          "decimals": 0,
+          "format": "short",
+          "label": "Slow",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "interval": "",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_total_client_messages_received{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")\r",
+          "interval": "",
+          "legendFormat": "Ingress",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(solace_bridge_total_client_messages_sent{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")\r",
+          "interval": "",
+          "legendFormat": "Egress",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transfer Messages / sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:8295",
+          "decimals": 0,
+          "format": "short",
+          "label": "Msg",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:8296",
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "interval": "",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_current_ingress_rate_per_second{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")\r",
+          "interval": "",
+          "legendFormat": "Ingress",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(solace_bridge_current_egress_rate_per_second{instance=\"$instance\",vpn_name=\"$vpnName\",bridge_name=\"$bridgeName\",job=\"solace\"}, \"bridge_short\", \"$1\", \"bridgeName\", \"([\\\\w\\\\-]+).*\")\r",
+          "interval": "",
+          "legendFormat": "Egress",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transfer Volume / sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:8295",
+          "decimals": null,
+          "format": "short",
+          "label": "Msg / sec",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:8296",
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [
+    "solace",
+    "bridge"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(up{group=\"Solace\"}, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "index": -1,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(up{group=\"Solace\"}, instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "shunting-assistant-dev",
+          "value": "shunting-assistant-dev"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(solace_bridge_admin_state{instance=\"$instance\",job=\"solace\"}, vpn_name)",
+        "hide": 0,
+        "includeAll": false,
+        "index": -1,
+        "label": "VPN",
+        "multi": false,
+        "name": "vpnName",
+        "options": [],
+        "query": "label_values(solace_bridge_admin_state{instance=\"$instance\",job=\"solace\"}, vpn_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "shunting-assistant-dev_lta-dev",
+          "value": "shunting-assistant-dev_lta-dev"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(solace_bridge_admin_state{instance=\"$instance\",vpn_name=\"$vpnName\",job=\"solace\"}, bridge_name)",
+        "hide": 0,
+        "includeAll": false,
+        "index": -1,
+        "label": "Bridge",
+        "multi": false,
+        "name": "bridgeName",
+        "options": [],
+        "query": "label_values(solace_bridge_admin_state{instance=\"$instance\",vpn_name=\"$vpnName\",job=\"solace\"}, bridge_name)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Solace bridge",
+  "uid": "y3WWrMiMk",
+  "variables": {
+    "list": []
+  },
+  "version": 27
+}

--- a/grafana/solace-bridges-dashboard.json
+++ b/grafana/solace-bridges-dashboard.json
@@ -1,0 +1,1231 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:2448",
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1593431476662,
+  "links": [
+    {
+      "$$hashKey": "object:824",
+      "icon": "external link",
+      "includeVars": true,
+      "tags": [
+        "solace"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "$$hashKey": "object:231",
+      "icon": "external link",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Help: Bridges",
+      "tooltip": "Help: Bridges Monitoring Dashboard",
+      "type": "link",
+      "url": "https://confluence.sbb.ch/display/MOPRO/Solace+Monitoring+Dashboard%3A+Bridges"
+    }
+  ],
+  "panels": [
+    {
+      "columns": [],
+      "datasource": "Prometheus",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 18,
+      "pageSize": null,
+      "showHeader": true,
+      "sort": {
+        "col": 2,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:175",
+          "alias": "",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "link": false,
+          "linkTooltip": "Instance",
+          "linkUrl": "/d/y3WWrMiMk/solace-bridge?orgId=1&var-instance=$instance&var-vpnName=${__data.fields[vpn_name]}",
+          "mappingType": 1,
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "$$hashKey": "object:1498",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "__name__",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:176",
+          "alias": "Bridge",
+          "align": "right",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "link": true,
+          "linkTooltip": "Bridge",
+          "linkUrl": "/d/y3WWrMiMk/solace-bridge?orgId=1&var-instance=${instance}&var-vpnName=${__cell_8}&var-bridgeName=${__cell_2}",
+          "mappingType": 1,
+          "pattern": "bridge_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1725",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "group",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1736",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "instance",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1747",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "instance_short",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1758",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "job",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1769",
+          "alias": "VPN",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTooltip": "Bridge",
+          "linkUrl": "/d/y3WWrMiMk/solace-bridge?orgId=1&var-instance=${instance}&var-vpnName=${__cell_8}&var-bridgeName=${__cell_2}",
+          "mappingType": 1,
+          "pattern": "vpn_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1790",
+          "alias": "Admin State",
+          "align": "auto",
+          "colorMode": "row",
+          "colors": [
+            "#37872D",
+            "#E0B400",
+            "#C4162A"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "link": true,
+          "linkTooltip": "Bridge",
+          "linkUrl": "/d/y3WWrMiMk/solace-bridge?orgId=1&var-instance=${instance}&var-vpnName=${__cell_8}&var-bridgeName=${__cell_2}",
+          "mappingType": 1,
+          "pattern": "Value",
+          "thresholds": [
+            "1"
+          ],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "$$hashKey": "object:288",
+              "text": "up",
+              "value": "0"
+            },
+            {
+              "$$hashKey": "object:290",
+              "text": "down",
+              "value": "1"
+            }
+          ]
+        },
+        {
+          "$$hashKey": "object:195",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "vmrVersion",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_admin_state{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Bridge Admin Status",
+      "transform": "table",
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "cards": {
+        "cardHSpacing": 2,
+        "cardMinWidth": 5,
+        "cardRound": null,
+        "cardVSpacing": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGnYlRd",
+        "defaultColor": "#757575",
+        "exponent": 0.5,
+        "mode": "discrete",
+        "thresholds": [
+          {
+            "$$hashKey": "object:3527",
+            "color": "red",
+            "tooltip": "down",
+            "value": "1"
+          },
+          {
+            "$$hashKey": "object:3529",
+            "color": "green",
+            "tooltip": "up",
+            "value": 0
+          }
+        ]
+      },
+      "data": {
+        "decimals": null,
+        "unitFormat": "short"
+      },
+      "datasource": "Prometheus",
+      "description": "Bridge Status: <<listing name of bridge - vpn name>> where the bridge is deployed to.",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "highlightCards": true,
+      "id": 2,
+      "interval": "",
+      "legend": {
+        "show": true
+      },
+      "links": [
+        {
+          "title": "Bridge Details",
+          "url": "/d/y3WWrMiMk/solace-bridge?orgId=1&refresh=10s&var-instance=${instance}"
+        }
+      ],
+      "nullPointMode": "as empty",
+      "repeat": null,
+      "repeatDirection": "v",
+      "seriesFilterIndex": -1,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_admin_state{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instanceName\", \"([\\\\w\\\\-]+).*\")",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{bridge_name}} - {{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Bridge Admin Status History",
+      "tooltip": {
+        "show": true
+      },
+      "type": "flant-statusmap-panel",
+      "urls": [
+        {
+          "base_url": "",
+          "extraSeries": {
+            "index": -1
+          },
+          "forcelowercase": true,
+          "icon_fa": "external-link",
+          "label": "",
+          "tooltip": "",
+          "useExtraSeries": false,
+          "useseriesname": true
+        }
+      ],
+      "useMax": true,
+      "usingUrl": false,
+      "xAxis": {
+        "labelFormat": "%a %m/%d",
+        "minBucketWidthToShowWeekends": 4,
+        "show": true,
+        "showCrosshair": true,
+        "showWeekends": true
+      },
+      "yAxis": {
+        "maxWidth": -1,
+        "minWidth": -1,
+        "show": true,
+        "showCrosshair": false
+      },
+      "yAxisSort": "metrics"
+    },
+    {
+      "collapsed": false,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Operational State",
+      "type": "row"
+    },
+    {
+      "cards": {
+        "cardHSpacing": 2,
+        "cardMinWidth": 5,
+        "cardRound": null,
+        "cardVSpacing": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGnYlRd",
+        "defaultColor": "#757575",
+        "exponent": 0.5,
+        "mode": "discrete",
+        "thresholds": [
+          {
+            "$$hashKey": "object:7612",
+            "color": "#C0D8FF",
+            "tooltip": "Init",
+            "value": "0"
+          },
+          {
+            "$$hashKey": "object:7616",
+            "color": "#C4162A",
+            "tooltip": "Shutdown",
+            "value": "1"
+          },
+          {
+            "$$hashKey": "object:7620",
+            "color": "#8AB8FF",
+            "tooltip": "NoShutdown",
+            "value": "2"
+          },
+          {
+            "$$hashKey": "object:7624",
+            "color": "#3274D9",
+            "tooltip": "Prepare",
+            "value": "3"
+          },
+          {
+            "$$hashKey": "object:7628",
+            "color": "#1F60C4",
+            "tooltip": "WaitToConnect",
+            "value": "4"
+          },
+          {
+            "$$hashKey": "object:7632",
+            "color": "#FADE2A",
+            "tooltip": "FetchingDNS",
+            "value": "5"
+          },
+          {
+            "$$hashKey": "object:7636",
+            "color": "#FADE2A",
+            "tooltip": "NotReady",
+            "value": "6"
+          },
+          {
+            "$$hashKey": "object:7640",
+            "color": "#FADE2A",
+            "tooltip": "Connecting",
+            "value": "7"
+          },
+          {
+            "$$hashKey": "object:7644",
+            "color": "#FADE2A",
+            "tooltip": "Handshaking",
+            "value": "8"
+          },
+          {
+            "$$hashKey": "object:7648",
+            "color": "#FADE2A",
+            "tooltip": "WaitNext",
+            "value": "9"
+          },
+          {
+            "$$hashKey": "object:7652",
+            "color": "#FADE2A",
+            "tooltip": "WaitReuse",
+            "value": "10"
+          },
+          {
+            "$$hashKey": "object:7656",
+            "color": "#FADE2A",
+            "tooltip": "WaitBridgeVersionMismatch",
+            "value": "11"
+          },
+          {
+            "$$hashKey": "object:720",
+            "color": "#FADE2A",
+            "tooltip": "WaitCleanup",
+            "value": "12"
+          },
+          {
+            "$$hashKey": "object:727",
+            "color": "#96D98D",
+            "tooltip": "Ready",
+            "value": "13"
+          },
+          {
+            "$$hashKey": "object:734",
+            "color": "#56A64B",
+            "tooltip": "Subscribing",
+            "value": "14"
+          },
+          {
+            "$$hashKey": "object:741",
+            "color": "#37872D",
+            "tooltip": "InSync",
+            "value": "15"
+          },
+          {
+            "$$hashKey": "object:748",
+            "color": "#B877D9",
+            "tooltip": "NotApplicable",
+            "value": "16"
+          },
+          {
+            "$$hashKey": "object:755",
+            "color": "#F2495C",
+            "tooltip": "Invalid",
+            "value": "17"
+          },
+          {
+            "$$hashKey": "object:786",
+            "color": "#C4162A",
+            "tooltip": "unknown",
+            "value": "-1"
+          }
+        ]
+      },
+      "data": {
+        "decimals": null,
+        "unitFormat": "short"
+      },
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "highlightCards": true,
+      "id": 20,
+      "legend": {
+        "show": true
+      },
+      "nullPointMode": "as empty",
+      "seriesFilterIndex": -1,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_inbound_operational_state{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instanceName\", \"([\\\\w\\\\-]+).*\")\r",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{bridge_name}} - {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Inbound",
+      "tooltip": {
+        "show": true
+      },
+      "type": "flant-statusmap-panel",
+      "urls": [
+        {
+          "base_url": "",
+          "extraSeries": {
+            "index": -1
+          },
+          "forcelowercase": true,
+          "icon_fa": "external-link",
+          "label": "",
+          "tooltip": "",
+          "useExtraSeries": false,
+          "useseriesname": true
+        }
+      ],
+      "useMax": true,
+      "usingUrl": false,
+      "xAxis": {
+        "labelFormat": "%a %m/%d",
+        "minBucketWidthToShowWeekends": 4,
+        "show": true,
+        "showCrosshair": true,
+        "showWeekends": true
+      },
+      "yAxis": {
+        "maxWidth": -1,
+        "minWidth": -1,
+        "show": true,
+        "showCrosshair": false
+      },
+      "yAxisSort": "metrics"
+    },
+    {
+      "cards": {
+        "cardHSpacing": 2,
+        "cardMinWidth": 5,
+        "cardRound": null,
+        "cardVSpacing": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGnYlRd",
+        "defaultColor": "#757575",
+        "exponent": 0.5,
+        "mode": "discrete",
+        "thresholds": [
+          {
+            "$$hashKey": "object:7612",
+            "color": "#C0D8FF",
+            "tooltip": "Init",
+            "value": "0"
+          },
+          {
+            "$$hashKey": "object:7616",
+            "color": "#C4162A",
+            "tooltip": "Shutdown",
+            "value": "1"
+          },
+          {
+            "$$hashKey": "object:7620",
+            "color": "#8AB8FF",
+            "tooltip": "NoShutdown",
+            "value": "2"
+          },
+          {
+            "$$hashKey": "object:7624",
+            "color": "#3274D9",
+            "tooltip": "Prepare",
+            "value": "3"
+          },
+          {
+            "$$hashKey": "object:7628",
+            "color": "#1F60C4",
+            "tooltip": "WaitToConnect",
+            "value": "4"
+          },
+          {
+            "$$hashKey": "object:7632",
+            "color": "#FADE2A",
+            "tooltip": "FetchingDNS",
+            "value": "5"
+          },
+          {
+            "$$hashKey": "object:7636",
+            "color": "#FADE2A",
+            "tooltip": "NotReady",
+            "value": "6"
+          },
+          {
+            "$$hashKey": "object:7640",
+            "color": "#FADE2A",
+            "tooltip": "Connecting",
+            "value": "7"
+          },
+          {
+            "$$hashKey": "object:7644",
+            "color": "#FADE2A",
+            "tooltip": "Handshaking",
+            "value": "8"
+          },
+          {
+            "$$hashKey": "object:7648",
+            "color": "#FADE2A",
+            "tooltip": "WaitNext",
+            "value": "9"
+          },
+          {
+            "$$hashKey": "object:7652",
+            "color": "#FADE2A",
+            "tooltip": "WaitReuse",
+            "value": "10"
+          },
+          {
+            "$$hashKey": "object:7656",
+            "color": "#FADE2A",
+            "tooltip": "WaitBridgeVersionMismatch",
+            "value": "11"
+          },
+          {
+            "$$hashKey": "object:720",
+            "color": "#FADE2A",
+            "tooltip": "WaitCleanup",
+            "value": "12"
+          },
+          {
+            "$$hashKey": "object:727",
+            "color": "#96D98D",
+            "tooltip": "Ready",
+            "value": "13"
+          },
+          {
+            "$$hashKey": "object:734",
+            "color": "#56A64B",
+            "tooltip": "Subscribing",
+            "value": "14"
+          },
+          {
+            "$$hashKey": "object:741",
+            "color": "#37872D",
+            "tooltip": "InSync",
+            "value": "15"
+          },
+          {
+            "$$hashKey": "object:748",
+            "color": "#B877D9",
+            "tooltip": "NotApplicable",
+            "value": "16"
+          },
+          {
+            "$$hashKey": "object:755",
+            "color": "#F2495C",
+            "tooltip": "Invalid",
+            "value": "17"
+          },
+          {
+            "$$hashKey": "object:786",
+            "color": "#C4162A",
+            "tooltip": "unknown",
+            "value": "-1"
+          }
+        ]
+      },
+      "data": {
+        "decimals": null,
+        "unitFormat": "short"
+      },
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "highlightCards": true,
+      "id": 21,
+      "legend": {
+        "show": true
+      },
+      "nullPointMode": "as empty",
+      "seriesFilterIndex": -1,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_outbound_operational_state{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instanceName\", \"([\\\\w\\\\-]+).*\")\r",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{bridge_name}} - {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Outbound",
+      "tooltip": {
+        "show": true
+      },
+      "type": "flant-statusmap-panel",
+      "urls": [
+        {
+          "base_url": "",
+          "extraSeries": {
+            "index": -1
+          },
+          "forcelowercase": true,
+          "icon_fa": "external-link",
+          "label": "",
+          "tooltip": "",
+          "useExtraSeries": false,
+          "useseriesname": true
+        }
+      ],
+      "useMax": true,
+      "usingUrl": false,
+      "xAxis": {
+        "labelFormat": "%a %m/%d",
+        "minBucketWidthToShowWeekends": 4,
+        "show": true,
+        "showCrosshair": true,
+        "showWeekends": true
+      },
+      "yAxis": {
+        "maxWidth": -1,
+        "minWidth": -1,
+        "show": true,
+        "showCrosshair": false
+      },
+      "yAxisSort": "metrics"
+    },
+    {
+      "cards": {
+        "cardHSpacing": 2,
+        "cardMinWidth": 5,
+        "cardRound": null,
+        "cardVSpacing": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGnYlRd",
+        "defaultColor": "#757575",
+        "exponent": 0.5,
+        "mode": "discrete",
+        "thresholds": [
+          {
+            "$$hashKey": "object:7612",
+            "color": "#B877D9",
+            "tooltip": "NotApplicable",
+            "value": "0"
+          },
+          {
+            "$$hashKey": "object:7616",
+            "color": "#37872D",
+            "tooltip": "Bound",
+            "value": "1"
+          },
+          {
+            "$$hashKey": "object:7620",
+            "color": "#96D98D",
+            "tooltip": "Unbound",
+            "value": "2"
+          },
+          {
+            "$$hashKey": "object:786",
+            "color": "#F2495C",
+            "tooltip": "unknown",
+            "value": "-1"
+          }
+        ]
+      },
+      "data": {
+        "decimals": null,
+        "unitFormat": "short"
+      },
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "highlightCards": true,
+      "id": 23,
+      "legend": {
+        "show": true
+      },
+      "nullPointMode": "as empty",
+      "seriesFilterIndex": -1,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_queue_operational_state{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instanceName\", \"([\\\\w\\\\-]+).*\")\r",
+          "interval": "",
+          "legendFormat": "{{bridge_name}} - {{vpn_name}}",
+          "refId": "C"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Queue",
+      "tooltip": {
+        "show": true
+      },
+      "type": "flant-statusmap-panel",
+      "urls": [
+        {
+          "base_url": "",
+          "extraSeries": {
+            "index": -1
+          },
+          "forcelowercase": true,
+          "icon_fa": "external-link",
+          "label": "",
+          "tooltip": "",
+          "useExtraSeries": false,
+          "useseriesname": true
+        }
+      ],
+      "useMax": true,
+      "usingUrl": false,
+      "xAxis": {
+        "labelFormat": "%a %m/%d",
+        "minBucketWidthToShowWeekends": 4,
+        "show": true,
+        "showCrosshair": true,
+        "showWeekends": true
+      },
+      "yAxis": {
+        "maxWidth": -1,
+        "minWidth": -1,
+        "show": true,
+        "showCrosshair": false
+      },
+      "yAxisSort": "metrics"
+    },
+    {
+      "collapsed": false,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 6,
+      "panels": [],
+      "repeat": null,
+      "title": "Bridges",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 45
+      },
+      "id": 4,
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [],
+            "max": 50,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 40
+                }
+              ]
+            },
+            "title": "total"
+          },
+          "overrides": [],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridges_num_total_bridges{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 45
+      },
+      "id": 8,
+      "interval": "",
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [],
+            "max": 25,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 20
+                }
+              ]
+            },
+            "title": "local"
+          },
+          "overrides": [],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridges_num_local_bridges{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 45
+      },
+      "id": 7,
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [],
+            "max": 25,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 20
+                }
+              ]
+            },
+            "title": "remote"
+          },
+          "overrides": [],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridges_num_remote_bridges{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "gauge"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridges_num_total_remote_bridge_subscriptions{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"\")",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Current",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(solace_bridges_max_num_total_remote_bridge_subscriptions{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"\")",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Max ",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Subscriptions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:826",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:827",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [
+    "solace",
+    "bridge"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(up{group=\"Solace\"}, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "index": -1,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(up{group=\"Solace\"}, instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Solace bridges",
+  "uid": "0zeRtZmGk",
+  "variables": {
+    "list": []
+  },
+  "version": 59
+}

--- a/grafana/solace-broker-dashboard.json
+++ b/grafana/solace-broker-dashboard.json
@@ -1,0 +1,2338 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:10",
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Analyse solace PubSub+ VPNs",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 2,
+  "iteration": 1593433934225,
+  "links": [
+    {
+      "$$hashKey": "object:110",
+      "icon": "external link",
+      "includeVars": true,
+      "tags": [
+        "solace"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "$$hashKey": "object:224",
+      "icon": "external link",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Help: Broker",
+      "tooltip": "Help: Broker Monitoring Dashboard",
+      "type": "link",
+      "url": "https://confluence.sbb.ch/display/MOPRO/Solace+Monitoring+Dashboard%3A+Broker"
+    }
+  ],
+  "panels": [
+    {
+      "cards": {
+        "cardHSpacing": 0,
+        "cardMinWidth": 5,
+        "cardRound": null,
+        "cardVSpacing": 0
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGnYlRd",
+        "defaultColor": "#757575",
+        "exponent": 0.5,
+        "mode": "discrete",
+        "thresholds": [
+          {
+            "$$hashKey": "object:1678",
+            "color": "red",
+            "tooltip": "down",
+            "value": "0"
+          },
+          {
+            "$$hashKey": "object:1680",
+            "color": "green",
+            "tooltip": "up",
+            "value": "1"
+          }
+        ]
+      },
+      "data": {
+        "decimals": null,
+        "unitFormat": "short"
+      },
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 9,
+        "x": 0,
+        "y": 0
+      },
+      "highlightCards": true,
+      "id": 6,
+      "legend": {
+        "show": true
+      },
+      "links": [
+        {
+          "title": "Brokers Overview",
+          "url": "/d/mz7SR9EZk/solace-brokers?orgId=1"
+        }
+      ],
+      "nullPointMode": "as empty",
+      "seriesFilterIndex": -1,
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " ",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Broker status",
+      "tooltip": {
+        "show": true
+      },
+      "transparent": true,
+      "type": "flant-statusmap-panel",
+      "urls": [
+        {
+          "base_url": "",
+          "extraSeries": {
+            "index": -1
+          },
+          "forcelowercase": true,
+          "icon_fa": "external-link",
+          "label": "",
+          "tooltip": "",
+          "useExtraSeries": false,
+          "useseriesname": true
+        }
+      ],
+      "useMax": true,
+      "usingUrl": false,
+      "xAxis": {
+        "labelFormat": "%a %m/%d",
+        "minBucketWidthToShowWeekends": 4,
+        "show": true,
+        "showCrosshair": true,
+        "showWeekends": true
+      },
+      "yAxis": {
+        "maxWidth": -1,
+        "minWidth": -1,
+        "show": true,
+        "showCrosshair": false
+      },
+      "yAxisSort": "metrics"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Redundancy status for High Availability support on this broker",
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 0
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Remote Active",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Local Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "Not HA",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_redundancy_local_active{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Redundancy Status",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Network latency to HA mate, empty in case of no HA configured",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 20,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "-1",
+                "id": 1,
+                "operator": "",
+                "text": " ",
+                "to": "0",
+                "type": 2,
+                "value": "NaN"
+              }
+            ],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 1e-20
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "latency for disk read/write operations",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 21,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "latency for CPU instructions  on the broker",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 22,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "gauge"
+    },
+    {
+      "content": "Sol Ver\nsion",
+      "datasource": null,
+      "gridPos": {
+        "h": 3,
+        "w": 1,
+        "x": 0,
+        "y": 4
+      },
+      "id": 41,
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 1,
+        "y": 4
+      },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "solace_system_version_currentload{instance=\"$instance\",job=\"solace\"}/1000000000",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 3,
+        "y": 4
+      },
+      "id": 37,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 0,
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": " ",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "(solace_system_version_currentload{instance=\"$instance\",job=\"solace\"} % 1000000000)/ 1000000",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 5,
+        "y": 4
+      },
+      "id": 38,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 0,
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": " ",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "(solace_system_version_currentload{instance=\"$instance\",job=\"solace\"} % 1000000)/ 100",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 7,
+        "y": 4
+      },
+      "id": 39,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 0,
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": " ",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "(solace_system_version_currentload{instance=\"$instance\",job=\"solace\"} % 1000)",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 9,
+        "y": 4
+      },
+      "id": 36,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_version_uptime_totalsecs{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Client Connections Count, per Vpn. Drill down into Vpn available",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 43,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": [
+          {
+            "title": "VPN ${__field.labels.vpn_name}",
+            "url": "d/FXk5NbPWz/solace-vpn?orgId=1&var-instance=${instance}&var-vpn_name=${__field.labels.vpn_name}"
+          }
+        ]
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=\"$instance\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "interval": "",
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Connections Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:816",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:817",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 15
+      },
+      "id": 31,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Disabled",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Enabled",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "2"
+              },
+              {
+                "from": "",
+                "id": 4,
+                "operator": "",
+                "text": "Not HA",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 2
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_redundancy_config{instance=\"$instance\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "System Redundancy Config",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 15
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Down",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Up",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": " ",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_redundancy_up{instance=\"$instance\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "System Redundancy Status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 15
+      },
+      "id": 33,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Backup",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Primary",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "Undefined",
+                "to": "",
+                "type": 1,
+                "value": "2"
+              },
+              {
+                "from": "",
+                "id": 4,
+                "operator": "",
+                "text": " ",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 50.5
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_redundancy_role{instance=\"$instance\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "System Redundancy Role",
+      "type": "stat"
+    },
+    {
+      "columns": [],
+      "datasource": "Prometheus",
+      "description": "Bridges Administrative Status, drill down into Bridge available",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 24,
+      "links": [
+        {
+          "title": "Bridges for this Broker",
+          "url": "http://monitoring-rcs.sbb.ch/d/0zeRtZmGk/solace-bridges?orgId=1&var-instance=${instance}"
+        }
+      ],
+      "pageSize": null,
+      "showHeader": true,
+      "sort": {
+        "col": 2,
+        "desc": true
+      },
+      "styles": [
+        {
+          "$$hashKey": "object:175",
+          "alias": "",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "link": false,
+          "linkTooltip": "Instance",
+          "linkUrl": "/d/y3WWrMiMk/solace-bridge?orgId=1&var-instance=$instance&var-vpnName=${__data.fields[vpn_name]}",
+          "mappingType": 1,
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "$$hashKey": "object:1498",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "__name__",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:176",
+          "alias": "Bridge",
+          "align": "right",
+          "colorMode": "value",
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "decimals": 2,
+          "link": true,
+          "linkTargetBlank": false,
+          "linkTooltip": "Bridge",
+          "linkUrl": "/d/y3WWrMiMk/solace-bridge?orgId=1&var-instance=${instance}&var-vpnName=${__cell_8}&&var-bridgeName=${__cell_2}",
+          "mappingType": 1,
+          "pattern": "bridge_name",
+          "thresholds": [
+            "1"
+          ],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1725",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "group",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1736",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "instance",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1747",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "instance_short",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1758",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "job",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1769",
+          "alias": "VPN",
+          "align": "auto",
+          "colorMode": "value",
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTargetBlank": false,
+          "linkTooltip": "Bridge",
+          "linkUrl": "/d/y3WWrMiMk/solace-bridge?orgId=1&var-instance=${instance}&var-vpnName=${__cell_8}&&var-bridgeName=${__cell_2}",
+          "mappingType": 1,
+          "pattern": "vpn_name",
+          "thresholds": [
+            "1"
+          ],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "$$hashKey": "object:1790",
+          "alias": "Admin State",
+          "align": "auto",
+          "colorMode": "row",
+          "colors": [
+            "#37872D",
+            "#E0B400",
+            "#C4162A"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "link": true,
+          "linkTargetBlank": false,
+          "linkTooltip": "Bridge",
+          "linkUrl": "/d/y3WWrMiMk/solace-bridge?orgId=1&var-instance=${instance}&var-vpnName=${__cell_8}&&var-bridgeName=${__cell_2}",
+          "mappingType": 1,
+          "pattern": "Value",
+          "thresholds": [
+            "1"
+          ],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "$$hashKey": "object:288",
+              "text": "up",
+              "value": "0"
+            },
+            {
+              "$$hashKey": "object:290",
+              "text": "down",
+              "value": "1"
+            }
+          ]
+        },
+        {
+          "$$hashKey": "object:867",
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "vmrVersion",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "label_replace(solace_bridge_admin_state{instance=\"$instance\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "AdminState",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Bridges Admin Status",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 19
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Down",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Up",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "Not HA",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              },
+              {
+                "from": "",
+                "id": 4,
+                "operator": "",
+                "text": "unknown",
+                "to": "",
+                "type": 1,
+                "value": "-1"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": -1
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_configsync_table_syncstate{instance=\"$instance\",table_name=\"site\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Config Sync State",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 19
+      },
+      "id": 28,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": " ",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_configsync_table_timeinstateseconds{instance=\"$instance\",table_name=\"site\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Time in this state",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 19
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Master",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Slave",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 4,
+                "operator": "",
+                "text": " ",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_configsync_table_ownership{instance=\"$instance\",table_name=\"site\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Config Sync Role",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=\"$instance\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}@{{instance_short}} IN",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "Bps",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=\"$instance\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}@{{instance_short}} OUT",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "Bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_msgs_total{instance=\"$instance\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}@{{instance_short}} IN",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transfer msgs IN",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_msgs_total{instance=\"$instance\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}@{{instance_short}} OUT",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transfer msgs OUT",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "decimals": 2,
+      "description": "Number of spooled messages on the broker, against max. quota of spool available",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "hiddenSeries": false,
+      "id": 45,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:1424",
+          "alias": "/quota .*/",
+          "color": "#F2495C",
+          "fill": 0
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_spool_usage_msgs{instance=\"$instance\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "spooled msgs {{instance_short}}",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(solace_system_spool_quota_msgs{instance=\"$instance\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "quota {{instance_short}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Spooled msgs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1439",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1440",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "decimals": 2,
+      "description": "Amount of spooled data on the broker, against max. quota of spool available",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "hiddenSeries": false,
+      "id": 47,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/quota .*/",
+          "color": "#F2495C",
+          "fill": 0
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_spool_usage_bytes{instance=\"$instance\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "spooled msgs {{instance_short}}",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(solace_system_spool_quota_bytes{instance=\"$instance\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "quota {{instance_short}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Spooled bytes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [
+    "solace",
+    "broker"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(up{group=\"Solace\"}, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "index": -1,
+        "label": "",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(up{group=\"Solace\"}, instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Solace broker",
+  "uid": "HUkhHbPWz",
+  "variables": {
+    "list": []
+  },
+  "version": 25
+}

--- a/grafana/solace-brokers-dashboard.json
+++ b/grafana/solace-brokers-dashboard.json
@@ -1,0 +1,21193 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:1314",
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Analyse solace PubSub+ VPNs",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 2,
+  "iteration": 1593433396486,
+  "links": [
+    {
+      "$$hashKey": "object:231",
+      "icon": "external link",
+      "includeVars": true,
+      "tags": [
+        "solace"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "$$hashKey": "object:1202",
+      "icon": "external link",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Help: Brokers",
+      "tooltip": "Help: Brokers Monitoring Dashboard",
+      "type": "link",
+      "url": "https://confluence.sbb.ch/display/MOPRO/Solace+Monitoring+Dashboard%3A+Brokers"
+    }
+  ],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": "instance",
+      "repeatDirection": "v",
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:10920",
+          "value": "ec2-6168.prod.aws.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 2,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": "instance",
+      "repeatDirection": "v",
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:10920",
+          "value": "ec2-6168.prod.aws.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 0
+      },
+      "id": 20,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": "instance",
+      "repeatDirection": "v",
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:10920",
+          "value": "ec2-6168.prod.aws.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 0
+      },
+      "id": 21,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": "instance",
+      "repeatDirection": "v",
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:10920",
+          "value": "ec2-6168.prod.aws.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 0
+      },
+      "id": 22,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": "instance",
+      "repeatDirection": "v",
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:10920",
+          "value": "ec2-6168.prod.aws.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 0
+      },
+      "id": 4,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": "instance",
+      "repeatDirection": "v",
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:10920",
+          "value": "ec2-6168.prod.aws.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 0
+      },
+      "id": 7,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": "instance",
+      "repeatDirection": "v",
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:10920",
+          "value": "ec2-6168.prod.aws.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 6
+      },
+      "id": 23,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:20920",
+          "value": "ec2-6168.prod.aws.sbb.ch:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 6
+      },
+      "id": 52,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:20920",
+          "value": "ec2-6168.prod.aws.sbb.ch:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 6
+      },
+      "id": 81,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:20920",
+          "value": "ec2-6168.prod.aws.sbb.ch:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 6
+      },
+      "id": 110,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:20920",
+          "value": "ec2-6168.prod.aws.sbb.ch:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 6
+      },
+      "id": 139,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:20920",
+          "value": "ec2-6168.prod.aws.sbb.ch:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 6
+      },
+      "id": 168,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:20920",
+          "value": "ec2-6168.prod.aws.sbb.ch:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 6
+      },
+      "id": 197,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:20920",
+          "value": "ec2-6168.prod.aws.sbb.ch:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 12
+      },
+      "id": 24,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:30920",
+          "value": "ec2-6168.prod.aws.sbb.ch:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 12
+      },
+      "id": 53,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:30920",
+          "value": "ec2-6168.prod.aws.sbb.ch:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 12
+      },
+      "id": 82,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:30920",
+          "value": "ec2-6168.prod.aws.sbb.ch:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 12
+      },
+      "id": 111,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:30920",
+          "value": "ec2-6168.prod.aws.sbb.ch:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 12
+      },
+      "id": 140,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:30920",
+          "value": "ec2-6168.prod.aws.sbb.ch:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 12
+      },
+      "id": 169,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:30920",
+          "value": "ec2-6168.prod.aws.sbb.ch:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 12
+      },
+      "id": 198,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:30920",
+          "value": "ec2-6168.prod.aws.sbb.ch:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 18
+      },
+      "id": 25,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:40920",
+          "value": "ec2-6168.prod.aws.sbb.ch:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 18
+      },
+      "id": 54,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:40920",
+          "value": "ec2-6168.prod.aws.sbb.ch:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 18
+      },
+      "id": 83,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:40920",
+          "value": "ec2-6168.prod.aws.sbb.ch:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 18
+      },
+      "id": 112,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:40920",
+          "value": "ec2-6168.prod.aws.sbb.ch:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 18
+      },
+      "id": 141,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:40920",
+          "value": "ec2-6168.prod.aws.sbb.ch:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 18
+      },
+      "id": 170,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:40920",
+          "value": "ec2-6168.prod.aws.sbb.ch:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 18
+      },
+      "id": 199,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:40920",
+          "value": "ec2-6168.prod.aws.sbb.ch:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 24
+      },
+      "id": 26,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:50920",
+          "value": "ec2-6168.prod.aws.sbb.ch:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 24
+      },
+      "id": 55,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:50920",
+          "value": "ec2-6168.prod.aws.sbb.ch:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 24
+      },
+      "id": 84,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:50920",
+          "value": "ec2-6168.prod.aws.sbb.ch:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 24
+      },
+      "id": 113,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:50920",
+          "value": "ec2-6168.prod.aws.sbb.ch:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 24
+      },
+      "id": 142,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:50920",
+          "value": "ec2-6168.prod.aws.sbb.ch:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 24
+      },
+      "id": 171,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:50920",
+          "value": "ec2-6168.prod.aws.sbb.ch:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 24
+      },
+      "id": 200,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "ec2-6168.prod.aws.sbb.ch:50920",
+          "value": "ec2-6168.prod.aws.sbb.ch:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 30
+      },
+      "id": 27,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg01.sbb.ch:9628",
+          "value": "rcsadlmsg01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 30
+      },
+      "id": 56,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg01.sbb.ch:9628",
+          "value": "rcsadlmsg01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 30
+      },
+      "id": 85,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg01.sbb.ch:9628",
+          "value": "rcsadlmsg01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 30
+      },
+      "id": 114,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg01.sbb.ch:9628",
+          "value": "rcsadlmsg01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 30
+      },
+      "id": 143,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg01.sbb.ch:9628",
+          "value": "rcsadlmsg01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 30
+      },
+      "id": 172,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg01.sbb.ch:9628",
+          "value": "rcsadlmsg01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 30
+      },
+      "id": 201,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg01.sbb.ch:9628",
+          "value": "rcsadlmsg01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 36
+      },
+      "id": 28,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg02.sbb.ch:9628",
+          "value": "rcsadlmsg02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 36
+      },
+      "id": 57,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg02.sbb.ch:9628",
+          "value": "rcsadlmsg02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 36
+      },
+      "id": 86,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg02.sbb.ch:9628",
+          "value": "rcsadlmsg02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 36
+      },
+      "id": 115,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg02.sbb.ch:9628",
+          "value": "rcsadlmsg02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 36
+      },
+      "id": 144,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg02.sbb.ch:9628",
+          "value": "rcsadlmsg02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 36
+      },
+      "id": 173,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg02.sbb.ch:9628",
+          "value": "rcsadlmsg02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 36
+      },
+      "id": 202,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "rcsadlmsg02.sbb.ch:9628",
+          "value": "rcsadlmsg02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 42
+      },
+      "id": 29,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-ato-otc1-p02.sbb.ch:10920",
+          "value": "s-ato-otc1-p02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 42
+      },
+      "id": 58,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-ato-otc1-p02.sbb.ch:10920",
+          "value": "s-ato-otc1-p02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 42
+      },
+      "id": 87,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-ato-otc1-p02.sbb.ch:10920",
+          "value": "s-ato-otc1-p02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 42
+      },
+      "id": 116,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-ato-otc1-p02.sbb.ch:10920",
+          "value": "s-ato-otc1-p02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 42
+      },
+      "id": 145,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-ato-otc1-p02.sbb.ch:10920",
+          "value": "s-ato-otc1-p02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 42
+      },
+      "id": 174,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-ato-otc1-p02.sbb.ch:10920",
+          "value": "s-ato-otc1-p02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 42
+      },
+      "id": 203,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-ato-otc1-p02.sbb.ch:10920",
+          "value": "s-ato-otc1-p02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 48
+      },
+      "id": 30,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-cop1-otc2-t01.sbb.ch:9628",
+          "value": "s-cop1-otc2-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 48
+      },
+      "id": 59,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-cop1-otc2-t01.sbb.ch:9628",
+          "value": "s-cop1-otc2-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 48
+      },
+      "id": 88,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-cop1-otc2-t01.sbb.ch:9628",
+          "value": "s-cop1-otc2-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 48
+      },
+      "id": 117,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-cop1-otc2-t01.sbb.ch:9628",
+          "value": "s-cop1-otc2-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 48
+      },
+      "id": 146,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-cop1-otc2-t01.sbb.ch:9628",
+          "value": "s-cop1-otc2-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 48
+      },
+      "id": 175,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-cop1-otc2-t01.sbb.ch:9628",
+          "value": "s-cop1-otc2-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 48
+      },
+      "id": 204,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-cop1-otc2-t01.sbb.ch:9628",
+          "value": "s-cop1-otc2-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 54
+      },
+      "id": 31,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-itv1-otc1-p01.sbb.ch:10920",
+          "value": "s-itv1-otc1-p01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 54
+      },
+      "id": 60,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-itv1-otc1-p01.sbb.ch:10920",
+          "value": "s-itv1-otc1-p01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 54
+      },
+      "id": 89,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-itv1-otc1-p01.sbb.ch:10920",
+          "value": "s-itv1-otc1-p01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 54
+      },
+      "id": 118,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-itv1-otc1-p01.sbb.ch:10920",
+          "value": "s-itv1-otc1-p01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 54
+      },
+      "id": 147,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-itv1-otc1-p01.sbb.ch:10920",
+          "value": "s-itv1-otc1-p01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 54
+      },
+      "id": 176,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-itv1-otc1-p01.sbb.ch:10920",
+          "value": "s-itv1-otc1-p01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 54
+      },
+      "id": 205,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-itv1-otc1-p01.sbb.ch:10920",
+          "value": "s-itv1-otc1-p01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 60
+      },
+      "id": 32,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt1-otc1-t01.sbb.ch:9628",
+          "value": "s-lt1-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 60
+      },
+      "id": 61,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt1-otc1-t01.sbb.ch:9628",
+          "value": "s-lt1-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 60
+      },
+      "id": 90,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt1-otc1-t01.sbb.ch:9628",
+          "value": "s-lt1-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 60
+      },
+      "id": 119,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt1-otc1-t01.sbb.ch:9628",
+          "value": "s-lt1-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 60
+      },
+      "id": 148,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt1-otc1-t01.sbb.ch:9628",
+          "value": "s-lt1-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 60
+      },
+      "id": 177,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt1-otc1-t01.sbb.ch:9628",
+          "value": "s-lt1-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 60
+      },
+      "id": 206,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt1-otc1-t01.sbb.ch:9628",
+          "value": "s-lt1-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 66
+      },
+      "id": 33,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt2-otc1-t01.sbb.ch:9628",
+          "value": "s-lt2-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 66
+      },
+      "id": 62,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt2-otc1-t01.sbb.ch:9628",
+          "value": "s-lt2-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 66
+      },
+      "id": 91,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt2-otc1-t01.sbb.ch:9628",
+          "value": "s-lt2-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 66
+      },
+      "id": 120,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt2-otc1-t01.sbb.ch:9628",
+          "value": "s-lt2-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 66
+      },
+      "id": 149,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt2-otc1-t01.sbb.ch:9628",
+          "value": "s-lt2-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 66
+      },
+      "id": 178,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt2-otc1-t01.sbb.ch:9628",
+          "value": "s-lt2-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 66
+      },
+      "id": 207,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-lt2-otc1-t01.sbb.ch:9628",
+          "value": "s-lt2-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 72
+      },
+      "id": 34,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-mon-otc1-t01.sbb.ch:9628",
+          "value": "s-mon-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 72
+      },
+      "id": 63,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-mon-otc1-t01.sbb.ch:9628",
+          "value": "s-mon-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 72
+      },
+      "id": 92,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-mon-otc1-t01.sbb.ch:9628",
+          "value": "s-mon-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 72
+      },
+      "id": 121,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-mon-otc1-t01.sbb.ch:9628",
+          "value": "s-mon-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 72
+      },
+      "id": 150,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-mon-otc1-t01.sbb.ch:9628",
+          "value": "s-mon-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 72
+      },
+      "id": 179,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-mon-otc1-t01.sbb.ch:9628",
+          "value": "s-mon-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 72
+      },
+      "id": 208,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-mon-otc1-t01.sbb.ch:9628",
+          "value": "s-mon-otc1-t01.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 78
+      },
+      "id": 35,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-rti-otc1-t02.sbb.ch:10920",
+          "value": "s-rti-otc1-t02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 78
+      },
+      "id": 64,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-rti-otc1-t02.sbb.ch:10920",
+          "value": "s-rti-otc1-t02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 78
+      },
+      "id": 93,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-rti-otc1-t02.sbb.ch:10920",
+          "value": "s-rti-otc1-t02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 78
+      },
+      "id": 122,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-rti-otc1-t02.sbb.ch:10920",
+          "value": "s-rti-otc1-t02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 78
+      },
+      "id": 151,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-rti-otc1-t02.sbb.ch:10920",
+          "value": "s-rti-otc1-t02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 78
+      },
+      "id": 180,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-rti-otc1-t02.sbb.ch:10920",
+          "value": "s-rti-otc1-t02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 78
+      },
+      "id": 209,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-rti-otc1-t02.sbb.ch:10920",
+          "value": "s-rti-otc1-t02.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 84
+      },
+      "id": 36,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 84
+      },
+      "id": 65,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 84
+      },
+      "id": 94,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 84
+      },
+      "id": 123,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 84
+      },
+      "id": 152,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 84
+      },
+      "id": 181,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 84
+      },
+      "id": 210,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 90
+      },
+      "id": 37,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i2-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i2-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 90
+      },
+      "id": 66,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i2-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i2-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 90
+      },
+      "id": 95,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i2-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i2-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 90
+      },
+      "id": 124,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i2-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i2-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 90
+      },
+      "id": 153,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i2-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i2-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 90
+      },
+      "id": 182,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i2-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i2-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 90
+      },
+      "id": 211,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "s-t-i2-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i2-otc1-t01.sbb.ch:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 96
+      },
+      "id": 38,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node01.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node01.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 96
+      },
+      "id": 67,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node01.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node01.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 96
+      },
+      "id": 96,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node01.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node01.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 96
+      },
+      "id": 125,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node01.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node01.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 96
+      },
+      "id": 154,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node01.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node01.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 96
+      },
+      "id": 183,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node01.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node01.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 96
+      },
+      "id": 212,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node01.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node01.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 102
+      },
+      "id": 39,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node02.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node02.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 102
+      },
+      "id": 68,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node02.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node02.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 102
+      },
+      "id": 97,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node02.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node02.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 102
+      },
+      "id": 126,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node02.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node02.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 102
+      },
+      "id": 155,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node02.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node02.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 102
+      },
+      "id": 184,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node02.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node02.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 102
+      },
+      "id": 213,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolace-node02.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolace-node02.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 108
+      },
+      "id": 40,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 108
+      },
+      "id": 69,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 108
+      },
+      "id": 98,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 108
+      },
+      "id": 127,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 108
+      },
+      "id": 156,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 108
+      },
+      "id": 185,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 108
+      },
+      "id": 214,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628",
+          "value": "shared-rcssolacemonitoring.otc-test.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 114
+      },
+      "id": 41,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:10920",
+          "value": "tms-mob-int01-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 114
+      },
+      "id": 70,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:10920",
+          "value": "tms-mob-int01-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 114
+      },
+      "id": 99,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:10920",
+          "value": "tms-mob-int01-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 114
+      },
+      "id": 128,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:10920",
+          "value": "tms-mob-int01-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 114
+      },
+      "id": 157,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:10920",
+          "value": "tms-mob-int01-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 114
+      },
+      "id": 186,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:10920",
+          "value": "tms-mob-int01-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 114
+      },
+      "id": 215,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:10920",
+          "value": "tms-mob-int01-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 120
+      },
+      "id": 42,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:20920",
+          "value": "tms-mob-int01-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 120
+      },
+      "id": 71,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:20920",
+          "value": "tms-mob-int01-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 120
+      },
+      "id": 100,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:20920",
+          "value": "tms-mob-int01-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 120
+      },
+      "id": 129,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:20920",
+          "value": "tms-mob-int01-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 120
+      },
+      "id": 158,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:20920",
+          "value": "tms-mob-int01-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 120
+      },
+      "id": 187,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:20920",
+          "value": "tms-mob-int01-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 120
+      },
+      "id": 216,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:20920",
+          "value": "tms-mob-int01-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 126
+      },
+      "id": 43,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:30920",
+          "value": "tms-mob-int01-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 126
+      },
+      "id": 72,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:30920",
+          "value": "tms-mob-int01-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 126
+      },
+      "id": 101,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:30920",
+          "value": "tms-mob-int01-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 126
+      },
+      "id": 130,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:30920",
+          "value": "tms-mob-int01-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 126
+      },
+      "id": 159,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:30920",
+          "value": "tms-mob-int01-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 126
+      },
+      "id": 188,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:30920",
+          "value": "tms-mob-int01-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 126
+      },
+      "id": 217,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:30920",
+          "value": "tms-mob-int01-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 132
+      },
+      "id": 44,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:40920",
+          "value": "tms-mob-int01-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 132
+      },
+      "id": 73,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:40920",
+          "value": "tms-mob-int01-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 132
+      },
+      "id": 102,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:40920",
+          "value": "tms-mob-int01-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 132
+      },
+      "id": 131,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:40920",
+          "value": "tms-mob-int01-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 132
+      },
+      "id": 160,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:40920",
+          "value": "tms-mob-int01-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 132
+      },
+      "id": 189,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:40920",
+          "value": "tms-mob-int01-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 132
+      },
+      "id": 218,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:40920",
+          "value": "tms-mob-int01-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 138
+      },
+      "id": 45,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:50920",
+          "value": "tms-mob-int01-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 138
+      },
+      "id": 74,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:50920",
+          "value": "tms-mob-int01-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 138
+      },
+      "id": 103,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:50920",
+          "value": "tms-mob-int01-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 138
+      },
+      "id": 132,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:50920",
+          "value": "tms-mob-int01-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 138
+      },
+      "id": 161,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:50920",
+          "value": "tms-mob-int01-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 138
+      },
+      "id": 190,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:50920",
+          "value": "tms-mob-int01-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 138
+      },
+      "id": 219,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int01-intern:50920",
+          "value": "tms-mob-int01-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 144
+      },
+      "id": 46,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:10920",
+          "value": "tms-mob-int02-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 144
+      },
+      "id": 75,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:10920",
+          "value": "tms-mob-int02-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 144
+      },
+      "id": 104,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:10920",
+          "value": "tms-mob-int02-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 144
+      },
+      "id": 133,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:10920",
+          "value": "tms-mob-int02-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 144
+      },
+      "id": 162,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:10920",
+          "value": "tms-mob-int02-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 144
+      },
+      "id": 191,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:10920",
+          "value": "tms-mob-int02-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 144
+      },
+      "id": 220,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:10920",
+          "value": "tms-mob-int02-intern:10920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 150
+      },
+      "id": 47,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:20920",
+          "value": "tms-mob-int02-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 150
+      },
+      "id": 76,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:20920",
+          "value": "tms-mob-int02-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 150
+      },
+      "id": 105,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:20920",
+          "value": "tms-mob-int02-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 150
+      },
+      "id": 134,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:20920",
+          "value": "tms-mob-int02-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 150
+      },
+      "id": 163,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:20920",
+          "value": "tms-mob-int02-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 150
+      },
+      "id": 192,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:20920",
+          "value": "tms-mob-int02-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 150
+      },
+      "id": 221,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:20920",
+          "value": "tms-mob-int02-intern:20920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 156
+      },
+      "id": 48,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:30920",
+          "value": "tms-mob-int02-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 156
+      },
+      "id": 77,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:30920",
+          "value": "tms-mob-int02-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 156
+      },
+      "id": 106,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:30920",
+          "value": "tms-mob-int02-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 156
+      },
+      "id": 135,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:30920",
+          "value": "tms-mob-int02-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 156
+      },
+      "id": 164,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:30920",
+          "value": "tms-mob-int02-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 156
+      },
+      "id": 193,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:30920",
+          "value": "tms-mob-int02-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 156
+      },
+      "id": 222,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:30920",
+          "value": "tms-mob-int02-intern:30920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 162
+      },
+      "id": 49,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:40920",
+          "value": "tms-mob-int02-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 162
+      },
+      "id": 78,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:40920",
+          "value": "tms-mob-int02-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 162
+      },
+      "id": 107,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:40920",
+          "value": "tms-mob-int02-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 162
+      },
+      "id": 136,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:40920",
+          "value": "tms-mob-int02-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 162
+      },
+      "id": 165,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:40920",
+          "value": "tms-mob-int02-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 162
+      },
+      "id": 194,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:40920",
+          "value": "tms-mob-int02-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 162
+      },
+      "id": 223,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:40920",
+          "value": "tms-mob-int02-intern:40920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 168
+      },
+      "id": 50,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:50920",
+          "value": "tms-mob-int02-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 168
+      },
+      "id": 79,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:50920",
+          "value": "tms-mob-int02-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 168
+      },
+      "id": 108,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:50920",
+          "value": "tms-mob-int02-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 168
+      },
+      "id": 137,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:50920",
+          "value": "tms-mob-int02-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 168
+      },
+      "id": 166,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:50920",
+          "value": "tms-mob-int02-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 168
+      },
+      "id": 195,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:50920",
+          "value": "tms-mob-int02-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 168
+      },
+      "id": 224,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tms-mob-int02-intern:50920",
+          "value": "tms-mob-int02-intern:50920"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 174
+      },
+      "id": 51,
+      "links": [
+        {
+          "targetBlank": false,
+          "title": "Broker View",
+          "url": "/d/HUkhHbPWz/solace-broker?orgId=1&$__url_time_range&$__all_variables"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Active",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Shutdown",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "N/A",
+                "to": "",
+                "type": 1,
+                "value": ".1"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "title": "${__series.name}"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "red",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "green",
+              "index": 1,
+              "value": 1
+            }
+          ],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal"
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 6,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tmsplt-otc2-t02.sbb.ch:9628",
+          "value": "tmsplt-otc2-t02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_up{instance=~\"$instance.*\",job=\"solace\"}, \"instance_short\", \"$1$2$3$4\", \"instance\", \"(^.+)(?:.sbb.ch){1}(:\\\\d+)|(^.+)(:\\\\d+)\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Clients simultaneously connected to a given Message VPN through all supported services",
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 174
+      },
+      "id": 80,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 800
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 900
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 800
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 900
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 2,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tmsplt-otc2-t02.sbb.ch:9628",
+          "value": "tmsplt-otc2-t02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=~\"$instance.*\",vpn_name!~\"#.*\",group=\"Solace\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "client connections",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on message HA replication",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 8,
+        "y": 174
+      },
+      "id": 109,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.01,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.007
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.008
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.007
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.008
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 20,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tmsplt-otc2-t02.sbb.ch:9628",
+          "value": "tmsplt-otc2-t02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_mate_link_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "mate link latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency on persistence for guaranteed messages",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 10,
+        "y": 174
+      },
+      "id": 138,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 21,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tmsplt-otc2-t02.sbb.ch:9628",
+          "value": "tmsplt-otc2-t02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_disk_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disk latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "measured latency for CPU instructions ",
+      "gridPos": {
+        "h": 6,
+        "w": 2,
+        "x": 12,
+        "y": 174
+      },
+      "id": 167,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 0.1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 0.07
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 0.08
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 0.07
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 0.08
+            }
+          ],
+          "values": false
+        },
+        "orientation": "vertical",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 22,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tmsplt-otc2-t02.sbb.ch:9628",
+          "value": "tmsplt-otc2-t02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(solace_system_compute_latency_avg_seconds{instance=~\"$instance.*\",vpn_name!~\"#.*\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "compute latency",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 14,
+        "y": 174
+      },
+      "id": 196,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 4,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tmsplt-otc2-t02.sbb.ch:9628",
+          "value": "tmsplt-otc2-t02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume IN",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 19,
+        "y": 174
+      },
+      "id": 225,
+      "links": [],
+      "options": {
+        "displayMode": "gradient",
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 10000000,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "index": 0,
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "index": 1,
+                  "value": 8000000
+                },
+                {
+                  "color": "red",
+                  "index": 2,
+                  "value": 9000000
+                }
+              ]
+            },
+            "unit": "Bps"
+          },
+          "overrides": [],
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 8000000
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 9000000
+            }
+          ],
+          "values": false
+        },
+        "orientation": "horizontal",
+        "showUnfilled": true
+      },
+      "pluginVersion": "6.7.2",
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1593433396486,
+      "repeatPanelId": 7,
+      "scopedVars": {
+        "instance": {
+          "selected": false,
+          "text": "tmsplt-otc2-t02.sbb.ch:9628",
+          "value": "tmsplt-otc2-t02.sbb.ch:9628"
+        }
+      },
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=~\"$instance.*\",vpn_name!~\"^#.+\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Transfer volume OUT",
+      "type": "bargauge"
+    }
+  ],
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [
+    "solace",
+    "broker"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(up{group=\"Solace\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "index": -1,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(up{group=\"Solace\"}, instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Solace brokers",
+  "uid": "mz7SR9EZk",
+  "variables": {
+    "list": []
+  },
+  "version": 26
+}

--- a/grafana/solace-vpns-dashboard.json
+++ b/grafana/solace-vpns-dashboard.json
@@ -1,0 +1,1308 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:61",
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Analyse solace PubSub+ VPNs",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 2,
+  "iteration": 1593432899224,
+  "links": [
+    {
+      "$$hashKey": "object:260",
+      "icon": "external link",
+      "includeVars": true,
+      "tags": [
+        "solace"
+      ],
+      "type": "dashboards"
+    },
+    {
+      "$$hashKey": "object:1043",
+      "icon": "external link",
+      "tags": [],
+      "targetBlank": true,
+      "title": "Help: Vpn",
+      "tooltip": "Help: Vpn Monitoring Dashboard",
+      "type": "link",
+      "url": "https://confluence.sbb.ch/display/MOPRO/Solace+Monitoring+Dashboard%3A+Vpn"
+    }
+  ],
+  "panels": [
+    {
+      "cards": {
+        "cardHSpacing": 2,
+        "cardMinWidth": 5,
+        "cardRound": null,
+        "cardVSpacing": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGnYlRd",
+        "defaultColor": "#757575",
+        "exponent": 0.5,
+        "mode": "discrete",
+        "thresholds": [
+          {
+            "$$hashKey": "object:728",
+            "color": "red",
+            "tooltip": "Down",
+            "value": "0"
+          },
+          {
+            "$$hashKey": "object:730",
+            "color": "green",
+            "tooltip": "Up",
+            "value": "1"
+          }
+        ]
+      },
+      "data": {
+        "decimals": null,
+        "unitFormat": "short"
+      },
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "highlightCards": true,
+      "id": 6,
+      "legend": {
+        "show": true
+      },
+      "links": [],
+      "nullPointMode": "as empty",
+      "seriesFilterIndex": -1,
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_local_status{instance=\"$instance\",vpn_name=\"$vpn_name\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " ",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "VPN Local Status",
+      "tooltip": {
+        "show": true
+      },
+      "transparent": true,
+      "type": "flant-statusmap-panel",
+      "urls": [
+        {
+          "base_url": "",
+          "extraSeries": {
+            "index": -1
+          },
+          "forcelowercase": true,
+          "icon_fa": "external-link",
+          "label": "",
+          "tooltip": "",
+          "useExtraSeries": false,
+          "useseriesname": true
+        }
+      ],
+      "useMax": true,
+      "usingUrl": false,
+      "xAxis": {
+        "labelFormat": "%a %m/%d",
+        "minBucketWidthToShowWeekends": 4,
+        "show": true,
+        "showCrosshair": true,
+        "showWeekends": true
+      },
+      "yAxis": {
+        "maxWidth": -1,
+        "minWidth": -1,
+        "show": true,
+        "showCrosshair": false
+      },
+      "yAxisSort": "metrics"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Down",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Up",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": "not configured",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_configsync_table_syncstate{instance=\"$instance\",table_name=\"$vpn_name\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Config Sync Status",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "empty in case of Config State is not configured",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": " ",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_configsync_table_timeinstateseconds{instance=\"$instance\",table_name=\"$vpn_name\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Time in this state",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Part taken in the Config Sync setup, empty in case Config Sync is not configured",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "Master",
+                "to": "",
+                "type": 1,
+                "value": "0"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "Slave",
+                "to": "",
+                "type": 1,
+                "value": "1"
+              },
+              {
+                "from": "",
+                "id": 3,
+                "operator": "",
+                "text": " ",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.7.2",
+      "targets": [
+        {
+          "expr": "label_replace(solace_configsync_table_ownership{instance=\"$instance\",table_name=\"$vpn_name\",job=\"solace\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Config Sync Role",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(solace_vpn_connections{instance=\"$instance\",vpn_name=\"$vpn_name\"}, \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": " {{vpn_name}}@{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Client connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1806",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1807",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_bytes_total{instance=\"$instance\",vpn_name=\"$vpn_name\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}@{{instance_short}} IN",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_bytes_total{instance=\"$instance\",vpn_name=\"$vpn_name\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}@{{instance_short}} OUT",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transfer volume / sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1885",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1886",
+          "format": "Bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(irate(solace_vpn_rx_msgs_total{instance=\"$instance\",vpn_name=\"$vpn_name\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}@{{instance_short}} IN",
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(irate(solace_vpn_tx_msgs_total{instance=\"$instance\",vpn_name=\"$vpn_name\"}[5m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vpn_name}}@{{instance_short}} OUT",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Transfer Messages / sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1956",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1957",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "\n## Clients\n\nlist of flashy/possible problematic clients\n\n\n\n",
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 11,
+      "links": [],
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "expr": "label_replace(count_over_time((irate(solace_client_rx_discarded_msgs_total{instance=\"$instance\",vpn_name=\"$vpn_name\"}[15m]) > 0)[1m:10s]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{client_username}} ({{client_name}}) {{vpn_name}}@{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Clients discarded msgs IN",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2035",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2036",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 15,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "expr": "label_replace(count_over_time((irate(solace_client_tx_discarded_msgs_total{instance=\"$instance\",vpn_name=\"$vpn_name\"}[15m]) > 0)[1m:10s]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{client_username}} ({{client_name}}) {{vpn_name}}@{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Clients discarded msgs OUT",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:106",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:107",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(count_over_time((solace_client_slow_subscriber{instance=\"$instance\",vpn_name=\"$vpn_name\"} > 0)[5m:10s]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{client_username}} ({{client_name}}) {{vpn_name}}@{{instance_short}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Clients slow subscriber",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2205",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": "1",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2206",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "content": "## Queue\n\n\n",
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 14,
+      "links": [],
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "decimals": 0,
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "hiddenSeries": false,
+      "id": 9,
+      "interval": "15m",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "label_replace(count_over_time((irate(solace_queue_binds{instance=\"$instance\",vpn_name=\"$vpn_name\"}[15m]) < 1)[59s:1m]), \"instance_short\", \"$1\", \"instance\", \"([\\\\w\\\\-]+).*\")\n\n",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{queue_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Queues without consumer",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "Queues without consumer",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "decimals": 2,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "interval": "15m",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "expr": "solace_queue_spool_usage_bytes{instance=\"$instance\",vpn_name=\"$vpn_name\"} / solace_queue_spool_quota_bytes{instance=\"$instance\",vpn_name=\"$vpn_name\"} * 100",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{queue_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "$$hashKey": "object:2131",
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 90,
+          "yaxis": "left"
+        },
+        {
+          "$$hashKey": "object:2132",
+          "colorMode": "warning",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 80,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Queue quota usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2106",
+          "decimals": 0,
+          "format": "short",
+          "label": "%",
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2107",
+          "format": "short",
+          "label": "%",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [
+    "solace",
+    "vpn"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "s-t-i1-otc1-t01.sbb.ch:10920",
+          "value": "s-t-i1-otc1-t01.sbb.ch:10920"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(up{group=\"Solace\"}, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "index": -1,
+        "label": "",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(up{group=\"Solace\"}, instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "shunting-assistant-replay",
+          "value": "shunting-assistant-replay"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(solace_vpn_connections{instance=\"$instance\",group=\"Solace\"}, vpn_name)",
+        "hide": 0,
+        "includeAll": false,
+        "index": -1,
+        "label": "VPN",
+        "multi": false,
+        "name": "vpn_name",
+        "options": [],
+        "query": "label_values(solace_vpn_connections{instance=\"$instance\",group=\"Solace\"}, vpn_name)",
+        "refresh": 1,
+        "regex": "/^(?!#)/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Solace vpn",
+  "uid": "FXk5NbPWz",
+  "variables": {
+    "list": []
+  },
+  "version": 8
+}

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -1386,6 +1386,12 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		if up > 0 && e.config.redundancy {
 			up = e.getConfigSyncRouterSemp1(ch)
 		}
+	case scopeBrokerStatistics:
+		{
+		}
+	case scopeBrokerDetails:
+		{
+		}
 	case scopeVpnStandard:
 		if up > 0 {
 			up = e.getVpnReplicationSemp1(ch)
@@ -1413,8 +1419,10 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		if up > 0 {
 			up = e.getQueueDetailSemp1(ch)
 		}
-
 	default:
+		if up > 0 {
+			up = e.getVersionSemp1(ch)
+		}
 		if e.config.details {
 			if up > 0 {
 				up = e.getClientStatsSemp1(ch)

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -710,19 +710,22 @@ func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 	for _, bridge := range target.RPC.Show.Bridge.Bridges.Bridge {
 		bridgeName := bridge.BridgeName
 		vpnName := bridge.LocalVpnName
-
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_num_subscriptions"], prometheus.GaugeValue, bridge.Client.NumSubscriptions, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_slow_subscriber"], prometheus.GaugeValue, encodeMetricBool(bridge.Client.SlowSubscriber), vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_denied_duplicate_clients"], prometheus.GaugeValue, bridge.Client.Stats.DeniedDuplicateClients, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_enough_space_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotEnoughSpaceMsgsSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_max_exceeded_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.MaxExceededMsgsSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_found_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotFoundMsgsSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_ingress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentIngressRatePerSecond, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_egress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentEgressRatePerSecond, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_add_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.AddBySubscriptionManager, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_remove_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.RemoveBySubscriptionManager, vmrVersion, bridgeName, vpnName)
+		// check if this element is available in response, skip in case bridge down. In case up, assume the remaining child elements exist as well
+		var metric, err = prometheus.NewConstMetric(metricsStd["bridge_client_num_subscriptions"], prometheus.GaugeValue, bridge.Client.NumSubscriptions, vmrVersion, bridgeName, vpnName)
+		if err == nil {
+			ch <- metric
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_slow_subscriber"], prometheus.GaugeValue, encodeMetricBool(bridge.Client.SlowSubscriber), vmrVersion, bridgeName, vpnName)
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesReceived, vmrVersion, bridgeName, vpnName)
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesSent, vmrVersion, bridgeName, vpnName)
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_denied_duplicate_clients"], prometheus.GaugeValue, bridge.Client.Stats.DeniedDuplicateClients, vmrVersion, bridgeName, vpnName)
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_enough_space_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotEnoughSpaceMsgsSent, vmrVersion, bridgeName, vpnName)
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_max_exceeded_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.MaxExceededMsgsSent, vmrVersion, bridgeName, vpnName)
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_found_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotFoundMsgsSent, vmrVersion, bridgeName, vpnName)
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_ingress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentIngressRatePerSecond, vmrVersion, bridgeName, vpnName)
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_egress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentEgressRatePerSecond, vmrVersion, bridgeName, vpnName)
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_add_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.AddBySubscriptionManager, vmrVersion, bridgeName, vpnName)
+			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_remove_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.RemoveBySubscriptionManager, vmrVersion, bridgeName, vpnName)
+		}
 	}
 	return 1
 }

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -678,7 +678,7 @@ func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 										RemoveBySubscriptionManager float64 `xml:"remove-by-subscription-manager"`
 									} `xml:"managed-subscriptions"`
 								} `xml:"stats"`
-							} `xml:"client"`
+							} `xml:"client>."`
 						} `xml:"bridge"`
 					} `xml:"bridges"`
 				} `xml:"bridge"`
@@ -711,8 +711,8 @@ func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 		bridgeName := bridge.BridgeName
 		vpnName := bridge.LocalVpnName
 		// check if this element is available in response, skip in case bridge down. In case up, assume the remaining child elements exist as well
-		var metric, err = prometheus.NewConstMetric(metricsStd["bridge_client_num_subscriptions"], prometheus.GaugeValue, bridge.Client.NumSubscriptions, vmrVersion, bridgeName, vpnName)
-		if err == nil {
+		metric, _ := prometheus.NewConstMetric(metricsStd["bridge_client_num_subscriptions"], prometheus.GaugeValue, bridge.Client.NumSubscriptions, vmrVersion, bridgeName, vpnName)
+		if metric != nil {
 			ch <- metric
 			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_slow_subscriber"], prometheus.GaugeValue, encodeMetricBool(bridge.Client.SlowSubscriber), vmrVersion, bridgeName, vpnName)
 			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesReceived, vmrVersion, bridgeName, vpnName)

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -44,26 +44,23 @@ const (
 type metrics map[string]*prometheus.Desc
 
 var (
-	vmrVersion            = string("undefined")
 	solaceExporterVersion = float64(1002000)
 
-	variableLabelsVersion         = []string{"vmrVersion"}
-	variableExporterVersion       = []string{"vmrVersion"}
-	variableLabelsRedundancy      = []string{"vmrVersion", "mate_name"}
-	variableLabelsVpn             = []string{"vmrVersion", "vpn_name"}
-	variableLabelsVpnClient       = []string{"vmrVersion", "vpn_name", "client_name", "client_username"}
-	variableLabelsVpnQueue        = []string{"vmrVersion", "vpn_name", "queue_name"}
-	variableLabelsBridge          = []string{"vmrVersion", "bridge_name", "vpn_name"}
-	variableLabelsConfigSyncTable = []string{"vmrVersion", "table_name"}
+	variableLabelsRedundancy      = []string{"mate_name"}
+	variableLabelsVpn             = []string{"vpn_name"}
+	variableLabelsVpnClient       = []string{"vpn_name", "client_name", "client_username"}
+	variableLabelsVpnQueue        = []string{"vpn_name", "queue_name"}
+	variableLabelsBridge          = []string{"vpn_name", "bridge_name"}
+	variableLabelsConfigSyncTable = []string{"table_name"}
 
 	solaceUp = prometheus.NewDesc(namespace+"_"+"up", "Was the last scrape of Solace broker successful.", nil, nil)
 )
 
 var metricsStd = metrics{
 	// version
-	"system_version_currentload":      prometheus.NewDesc(namespace+"_"+"system_version_currentload", "Solace Version as WWWXXXYYYZZZ ", variableLabelsVersion, nil),
-	"system_version_uptime_totalsecs": prometheus.NewDesc(namespace+"_"+"system_version_uptime_totalsecs", "Broker uptime in seconds ", variableLabelsVersion, nil),
-	"exporter_version_current":        prometheus.NewDesc(namespace+"_"+"exporter_version_current", "Exporter Version ", variableLabelsVersion, nil),
+	"system_version_currentload":      prometheus.NewDesc(namespace+"_"+"system_version_currentload", "Solace Version as WWWXXXYYYZZZ ", nil, nil),
+	"system_version_uptime_totalsecs": prometheus.NewDesc(namespace+"_"+"system_version_uptime_totalsecs", "Broker uptime in seconds ", nil, nil),
+	"exporter_version_current":        prometheus.NewDesc(namespace+"_"+"exporter_version_current", "Exporter Version ", nil, nil),
 
 	// redundancy
 	"system_redundancy_up":           prometheus.NewDesc(namespace+"_"+"system_redundancy_up", "Is redundancy up? (0=down, 1=up).", variableLabelsRedundancy, nil),
@@ -72,22 +69,22 @@ var metricsStd = metrics{
 	"system_redundancy_local_active": prometheus.NewDesc(namespace+"_"+"system_redundancy_local_active", "Is local node the active messaging node? (0=not active, 1=active).", variableLabelsRedundancy, nil),
 
 	// system
-	"system_spool_quota_bytes":             prometheus.NewDesc(namespace+"_"+"system_spool_quota_bytes", "Spool configured max disk usage.", variableLabelsVersion, nil),
-	"system_spool_quota_msgs":              prometheus.NewDesc(namespace+"_"+"system_spool_quota_msgs", "Spool configured max number of messages.", variableLabelsVersion, nil),
-	"system_spool_usage_bytes":             prometheus.NewDesc(namespace+"_"+"system_spool_usage_bytes", "Spool total persisted usage.", variableLabelsVersion, nil),
-	"system_spool_usage_msgs":              prometheus.NewDesc(namespace+"_"+"system_spool_usage_msgs", "Spool total number of persisted messages.", variableLabelsVersion, nil),
-	"system_disk_latency_min_seconds":      prometheus.NewDesc(namespace+"_"+"system_disk_latency_min_seconds", "Minimum disk latency.", variableLabelsVersion, nil),
-	"system_disk_latency_max_seconds":      prometheus.NewDesc(namespace+"_"+"system_disk_latency_max_seconds", "Maximum disk latency.", variableLabelsVersion, nil),
-	"system_disk_latency_avg_seconds":      prometheus.NewDesc(namespace+"_"+"system_disk_latency_avg_seconds", "Average disk latency.", variableLabelsVersion, nil),
-	"system_disk_latency_cur_seconds":      prometheus.NewDesc(namespace+"_"+"system_disk_latency_cur_seconds", "Current disk latency.", variableLabelsVersion, nil),
-	"system_compute_latency_min_seconds":   prometheus.NewDesc(namespace+"_"+"system_compute_latency_min_seconds", "Minimum compute latency.", variableLabelsVersion, nil),
-	"system_compute_latency_max_seconds":   prometheus.NewDesc(namespace+"_"+"system_compute_latency_max_seconds", "Maximum compute latency.", variableLabelsVersion, nil),
-	"system_compute_latency_avg_seconds":   prometheus.NewDesc(namespace+"_"+"system_compute_latency_avg_seconds", "Average compute latency.", variableLabelsVersion, nil),
-	"system_compute_latency_cur_seconds":   prometheus.NewDesc(namespace+"_"+"system_compute_latency_cur_seconds", "Current compute latency.", variableLabelsVersion, nil),
-	"system_mate_link_latency_min_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_min_seconds", "Minimum mate link latency.", variableLabelsVersion, nil),
-	"system_mate_link_latency_max_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_max_seconds", "Maximum mate link latency.", variableLabelsVersion, nil),
-	"system_mate_link_latency_avg_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_avg_seconds", "Average mate link latency.", variableLabelsVersion, nil),
-	"system_mate_link_latency_cur_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_cur_seconds", "Current mate link latency.", variableLabelsVersion, nil),
+	"system_spool_quota_bytes":             prometheus.NewDesc(namespace+"_"+"system_spool_quota_bytes", "Spool configured max disk usage.", nil, nil),
+	"system_spool_quota_msgs":              prometheus.NewDesc(namespace+"_"+"system_spool_quota_msgs", "Spool configured max number of messages.", nil, nil),
+	"system_spool_usage_bytes":             prometheus.NewDesc(namespace+"_"+"system_spool_usage_bytes", "Spool total persisted usage.", nil, nil),
+	"system_spool_usage_msgs":              prometheus.NewDesc(namespace+"_"+"system_spool_usage_msgs", "Spool total number of persisted messages.", nil, nil),
+	"system_disk_latency_min_seconds":      prometheus.NewDesc(namespace+"_"+"system_disk_latency_min_seconds", "Minimum disk latency.", nil, nil),
+	"system_disk_latency_max_seconds":      prometheus.NewDesc(namespace+"_"+"system_disk_latency_max_seconds", "Maximum disk latency.", nil, nil),
+	"system_disk_latency_avg_seconds":      prometheus.NewDesc(namespace+"_"+"system_disk_latency_avg_seconds", "Average disk latency.", nil, nil),
+	"system_disk_latency_cur_seconds":      prometheus.NewDesc(namespace+"_"+"system_disk_latency_cur_seconds", "Current disk latency.", nil, nil),
+	"system_compute_latency_min_seconds":   prometheus.NewDesc(namespace+"_"+"system_compute_latency_min_seconds", "Minimum compute latency.", nil, nil),
+	"system_compute_latency_max_seconds":   prometheus.NewDesc(namespace+"_"+"system_compute_latency_max_seconds", "Maximum compute latency.", nil, nil),
+	"system_compute_latency_avg_seconds":   prometheus.NewDesc(namespace+"_"+"system_compute_latency_avg_seconds", "Average compute latency.", nil, nil),
+	"system_compute_latency_cur_seconds":   prometheus.NewDesc(namespace+"_"+"system_compute_latency_cur_seconds", "Current compute latency.", nil, nil),
+	"system_mate_link_latency_min_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_min_seconds", "Minimum mate link latency.", nil, nil),
+	"system_mate_link_latency_max_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_max_seconds", "Maximum mate link latency.", nil, nil),
+	"system_mate_link_latency_avg_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_avg_seconds", "Average mate link latency.", nil, nil),
+	"system_mate_link_latency_cur_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_cur_seconds", "Current mate link latency.", nil, nil),
 
 	// config sync
 	"configsync_table_type":               prometheus.NewDesc(namespace+"_"+"configsync_table_type", "Config Sync Resource Type", variableLabelsConfigSyncTable, nil),
@@ -109,14 +106,14 @@ var metricsStd = metrics{
 	"vpn_replication_transaction_replication_mode": prometheus.NewDesc(namespace+"_"+"vpn_replication_transaction_replication_mode", "Replication Tx Replication Mode", variableLabelsVpn, nil),
 
 	//bridges
-	"bridges_num_total_bridges":                         prometheus.NewDesc(namespace+"_"+"bridges_num_total_bridges", "Number of Bridges", variableLabelsVersion, nil),
-	"bridges_max_num_total_bridges":                     prometheus.NewDesc(namespace+"_"+"bridges_max_num_total_bridges", "Max number of Bridges", variableLabelsVersion, nil),
-	"bridges_num_local_bridges":                         prometheus.NewDesc(namespace+"_"+"bridges_num_local_bridges", "Number of Local Bridges", variableLabelsVersion, nil),
-	"bridges_max_num_local_bridges":                     prometheus.NewDesc(namespace+"_"+"bridges_max_num_local_bridges", "Max number of Local Bridges", variableLabelsVersion, nil),
-	"bridges_num_remote_bridges":                        prometheus.NewDesc(namespace+"_"+"bridges_num_remote_bridges", "Number of Remote Bridges", variableLabelsVersion, nil),
-	"bridges_max_num_remote_bridges":                    prometheus.NewDesc(namespace+"_"+"bridges_max_num_remote_bridges", "Max number of Remote Bridges", variableLabelsVersion, nil),
-	"bridges_num_total_remote_bridge_subscriptions":     prometheus.NewDesc(namespace+"_"+"bridges_num_total_remote_bridge_subscriptions", "Total number of Remote Bridge Subscription", variableLabelsVersion, nil),
-	"bridges_max_num_total_remote_bridge_subscriptions": prometheus.NewDesc(namespace+"_"+"bridges_max_num_total_remote_bridge_subscriptions", "Max total number of Remote Bridge Subscription", variableLabelsVersion, nil),
+	"bridges_num_total_bridges":                         prometheus.NewDesc(namespace+"_"+"bridges_num_total_bridges", "Number of Bridges", nil, nil),
+	"bridges_max_num_total_bridges":                     prometheus.NewDesc(namespace+"_"+"bridges_max_num_total_bridges", "Max number of Bridges", nil, nil),
+	"bridges_num_local_bridges":                         prometheus.NewDesc(namespace+"_"+"bridges_num_local_bridges", "Number of Local Bridges", nil, nil),
+	"bridges_max_num_local_bridges":                     prometheus.NewDesc(namespace+"_"+"bridges_max_num_local_bridges", "Max number of Local Bridges", nil, nil),
+	"bridges_num_remote_bridges":                        prometheus.NewDesc(namespace+"_"+"bridges_num_remote_bridges", "Number of Remote Bridges", nil, nil),
+	"bridges_max_num_remote_bridges":                    prometheus.NewDesc(namespace+"_"+"bridges_max_num_remote_bridges", "Max number of Remote Bridges", nil, nil),
+	"bridges_num_total_remote_bridge_subscriptions":     prometheus.NewDesc(namespace+"_"+"bridges_num_total_remote_bridge_subscriptions", "Total number of Remote Bridge Subscription", nil, nil),
+	"bridges_max_num_total_remote_bridge_subscriptions": prometheus.NewDesc(namespace+"_"+"bridges_max_num_total_remote_bridge_subscriptions", "Max total number of Remote Bridge Subscription", nil, nil),
 
 	// bridge
 	"bridge_admin_state":                            prometheus.NewDesc(namespace+"_"+"bridge_admin_state", "Bridge Administrative State (0-Enabled 1-Disabled)", variableLabelsBridge, nil),
@@ -162,11 +159,6 @@ var metricsStd = metrics{
 }
 
 var metricsDet = metrics{
-	// version
-	"system_version_currentload":      prometheus.NewDesc(namespace+"_"+"system_version_currentload", "Solace Version as WWWXXXYYYZZZ ", variableLabelsVersion, nil),
-	"system_version_uptime_totalsecs": prometheus.NewDesc(namespace+"_"+"system_version_uptime_totalsecs", "Broker uptime in seconds ", variableLabelsVersion, nil),
-	"exporter_version_current":        prometheus.NewDesc(namespace+"_"+"exporter_version_current", "Exporter Version ", variableLabelsVersion, nil),
-
 	"client_rx_msgs_total":           prometheus.NewDesc(namespace+"_"+"client_rx_msgs_total", "Number of received messages.", variableLabelsVpnClient, nil),
 	"client_tx_msgs_total":           prometheus.NewDesc(namespace+"_"+"client_tx_msgs_total", "Number of transmitted messages.", variableLabelsVpnClient, nil),
 	"client_rx_bytes_total":          prometheus.NewDesc(namespace+"_"+"client_rx_bytes_total", "Number of received bytes.", variableLabelsVpnClient, nil),
@@ -218,17 +210,7 @@ func (e *Exporter) postHTTP(uri string, contentType string, body string) (io.Rea
 	return resp.Body, nil
 }
 
-// Function to test if broker is up an can be scraped
-func (e *Exporter) checkBrokerAccess() (ok bool) {
-	_, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", "<rpc><show><version/></show></rpc>")
-	if err != nil {
-		level.Warn(e.logger).Log("msg", "Test scrape failed", "err", err, "hint", "A timeout error might indicate that the broker is not yet up")
-		return false
-	}
-	return true
-}
-
-// Get system-wide basic redundancy information for HA triples
+// Get version of broker
 func (e *Exporter) getVersionSemp1(ch chan<- prometheus.Metric) (ok float64) {
 
 	type Data struct {
@@ -272,9 +254,8 @@ func (e *Exporter) getVersionSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	}
 
 	// remember this for the label
-	vmrVersion = strings.TrimPrefix(target.RPC.Show.Version.CurrentLoad, "soltr_")
+	vmrVersion := strings.TrimPrefix(target.RPC.Show.Version.CurrentLoad, "soltr_")
 	// compute a version number so it can be measured by Prometheus
-
 	var vmrVersionStrBuffer bytes.Buffer
 	for _, s := range strings.Split(vmrVersion, ".") {
 		vmrVersionStrBuffer.WriteString(fmt.Sprintf("%03v", s))
@@ -282,9 +263,126 @@ func (e *Exporter) getVersionSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	var vmrVersionNr float64
 	vmrVersionNr, _ = strconv.ParseFloat(vmrVersionStrBuffer.String(), 64)
 
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_version_currentload"], prometheus.GaugeValue, vmrVersionNr, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_version_uptime_totalsecs"], prometheus.GaugeValue, target.RPC.Show.Version.Uptime.TotalSecs, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["exporter_version_current"], prometheus.GaugeValue, solaceExporterVersion, vmrVersion)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_version_currentload"], prometheus.GaugeValue, vmrVersionNr)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_version_uptime_totalsecs"], prometheus.GaugeValue, target.RPC.Show.Version.Uptime.TotalSecs)
+	ch <- prometheus.MustNewConstMetric(metricsStd["exporter_version_current"], prometheus.GaugeValue, solaceExporterVersion)
+
+	return 1
+}
+
+// Get system health information
+func (e *Exporter) getHealthSemp1(ch chan<- prometheus.Metric) (ok float64) {
+
+	type Data struct {
+		RPC struct {
+			Show struct {
+				System struct {
+					Health struct {
+						DiskLatencyMinimumValue     float64 `xml:"disk-latency-minimum-value"`
+						DiskLatencyMaximumValue     float64 `xml:"disk-latency-maximum-value"`
+						DiskLatencyAverageValue     float64 `xml:"disk-latency-average-value"`
+						DiskLatencyCurrentValue     float64 `xml:"disk-latency-current-value"`
+						ComputeLatencyMinimumValue  float64 `xml:"compute-latency-minimum-value"`
+						ComputeLatencyMaximumValue  float64 `xml:"compute-latency-maximum-value"`
+						ComputeLatencyAverageValue  float64 `xml:"compute-latency-average-value"`
+						ComputeLatencyCurrentValue  float64 `xml:"compute-latency-current-value"`
+						MateLinkLatencyMinimumValue float64 `xml:"mate-link-latency-minimum-value"`
+						MateLinkLatencyMaximumValue float64 `xml:"mate-link-latency-maximum-value"`
+						MateLinkLatencyAverageValue float64 `xml:"mate-link-latency-average-value"`
+						MateLinkLatencyCurrentValue float64 `xml:"mate-link-latency-current-value"`
+					} `xml:"health"`
+				} `xml:"system"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><system><health/></system></show ></rpc>"
+	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't scrape HealthSemp1", "err", err)
+		return 0
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't decode Xml HealthSemp1", "err", err)
+		return 0
+	}
+	if target.ExecuteResult.Result != "ok" {
+		level.Error(e.logger).Log("command", command)
+		return 0
+	}
+
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_disk_latency_min_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.DiskLatencyMinimumValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_disk_latency_max_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.DiskLatencyMaximumValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_disk_latency_avg_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.DiskLatencyAverageValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_disk_latency_cur_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.DiskLatencyCurrentValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_compute_latency_min_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.ComputeLatencyMinimumValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_compute_latency_max_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.ComputeLatencyMaximumValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_compute_latency_avg_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.ComputeLatencyAverageValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_compute_latency_cur_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.ComputeLatencyCurrentValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_mate_link_latency_min_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.MateLinkLatencyMinimumValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_mate_link_latency_max_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.MateLinkLatencyMaximumValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_mate_link_latency_avg_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.MateLinkLatencyAverageValue/1e6)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_mate_link_latency_cur_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.MateLinkLatencyCurrentValue/1e6)
+
+	return 1
+}
+
+// Get system-wide spool information
+func (e *Exporter) getSpoolSemp1(ch chan<- prometheus.Metric) (ok float64) {
+
+	type Data struct {
+		RPC struct {
+			Show struct {
+				Spool struct {
+					Info struct {
+						QuotaDiskUsage  float64 `xml:"max-disk-usage"`
+						QuotaMsgCount   string  `xml:"max-message-count"`
+						PersistUsage    float64 `xml:"current-persist-usage"`
+						PersistMsgCount float64 `xml:"total-messages-currently-spooled"`
+					} `xml:"message-spool-info"`
+				} `xml:"message-spool"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><message-spool></message-spool></show ></rpc>"
+	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't scrape Solace", "err", err)
+		return 0
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't decode Xml", "err", err)
+		return 0
+	}
+	if target.ExecuteResult.Result != "ok" {
+		level.Error(e.logger).Log("command", command)
+		return 0
+	}
+
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_spool_quota_bytes"], prometheus.GaugeValue, math.Round(target.RPC.Show.Spool.Info.QuotaDiskUsage*1048576.0))
+	// MaxMsgCount is in the form "100M"
+	s1 := target.RPC.Show.Spool.Info.QuotaMsgCount[:len(target.RPC.Show.Spool.Info.QuotaMsgCount)-1]
+	f1, err3 := strconv.ParseFloat(s1, 64)
+	if err3 == nil {
+		ch <- prometheus.MustNewConstMetric(metricsStd["system_spool_quota_msgs"], prometheus.GaugeValue, f1*1000000)
+	}
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_spool_usage_bytes"], prometheus.GaugeValue, math.Round(target.RPC.Show.Spool.Info.PersistUsage*1048576.0))
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_spool_usage_msgs"], prometheus.GaugeValue, target.RPC.Show.Spool.Info.PersistMsgCount)
 
 	return 1
 }
@@ -342,9 +440,9 @@ func (e *Exporter) getRedundancySemp1(ch chan<- prometheus.Metric) (ok float64) 
 	}
 
 	mateRouterName := "" + target.RPC.Show.Red.MateRouterName
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_redundancy_config"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Red.ConfigStatus, []string{"Disabled", "Enabled", "Shutdown"}), vmrVersion, mateRouterName)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_redundancy_up"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Red.RedundancyStatus, []string{"Down", "Up"}), vmrVersion, mateRouterName)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_redundancy_role"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Red.ActiveStandbyRole, []string{"Backup", "Primary", "Undefined"}), vmrVersion, mateRouterName)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_redundancy_config"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Red.ConfigStatus, []string{"Disabled", "Enabled", "Shutdown"}), mateRouterName)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_redundancy_up"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Red.RedundancyStatus, []string{"Down", "Up"}), mateRouterName)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_redundancy_role"], prometheus.GaugeValue, encodeMetricMulti(target.RPC.Show.Red.ActiveStandbyRole, []string{"Backup", "Primary", "Undefined"}), mateRouterName)
 
 	if target.RPC.Show.Red.ActiveStandbyRole == "Primary" && target.RPC.Show.Red.VirtualRouters.Primary.Status.Activity == "Local Active" ||
 		target.RPC.Show.Red.ActiveStandbyRole == "Backup" && target.RPC.Show.Red.VirtualRouters.Backup.Status.Activity == "Local Active" {
@@ -352,124 +450,7 @@ func (e *Exporter) getRedundancySemp1(ch chan<- prometheus.Metric) (ok float64) 
 	} else {
 		f = 0
 	}
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_redundancy_local_active"], prometheus.GaugeValue, f, vmrVersion, mateRouterName)
-
-	return 1
-}
-
-// Get system-wide spool information
-func (e *Exporter) getSpoolSemp1(ch chan<- prometheus.Metric) (ok float64) {
-
-	type Data struct {
-		RPC struct {
-			Show struct {
-				Spool struct {
-					Info struct {
-						QuotaDiskUsage  float64 `xml:"max-disk-usage"`
-						QuotaMsgCount   string  `xml:"max-message-count"`
-						PersistUsage    float64 `xml:"current-persist-usage"`
-						PersistMsgCount float64 `xml:"total-messages-currently-spooled"`
-					} `xml:"message-spool-info"`
-				} `xml:"message-spool"`
-			} `xml:"show"`
-		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-		} `xml:"execute-result"`
-	}
-
-	command := "<rpc><show><message-spool></message-spool></show ></rpc>"
-	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
-	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape Solace", "err", err)
-		return 0
-	}
-	defer body.Close()
-	decoder := xml.NewDecoder(body)
-	var target Data
-	err = decoder.Decode(&target)
-	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml", "err", err)
-		return 0
-	}
-	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
-		return 0
-	}
-
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_spool_quota_bytes"], prometheus.GaugeValue, math.Round(target.RPC.Show.Spool.Info.QuotaDiskUsage*1048576.0), vmrVersion)
-	// MaxMsgCount is in the form "100M"
-	s1 := target.RPC.Show.Spool.Info.QuotaMsgCount[:len(target.RPC.Show.Spool.Info.QuotaMsgCount)-1]
-	f1, err3 := strconv.ParseFloat(s1, 64)
-	if err3 == nil {
-		ch <- prometheus.MustNewConstMetric(metricsStd["system_spool_quota_msgs"], prometheus.GaugeValue, f1*1000000, vmrVersion)
-	}
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_spool_usage_bytes"], prometheus.GaugeValue, math.Round(target.RPC.Show.Spool.Info.PersistUsage*1048576.0), vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_spool_usage_msgs"], prometheus.GaugeValue, target.RPC.Show.Spool.Info.PersistMsgCount, vmrVersion)
-
-	return 1
-}
-
-// Get system health information
-func (e *Exporter) getHealthSemp1(ch chan<- prometheus.Metric) (ok float64) {
-
-	type Data struct {
-		RPC struct {
-			Show struct {
-				System struct {
-					Health struct {
-						DiskLatencyMinimumValue     float64 `xml:"disk-latency-minimum-value"`
-						DiskLatencyMaximumValue     float64 `xml:"disk-latency-maximum-value"`
-						DiskLatencyAverageValue     float64 `xml:"disk-latency-average-value"`
-						DiskLatencyCurrentValue     float64 `xml:"disk-latency-current-value"`
-						ComputeLatencyMinimumValue  float64 `xml:"compute-latency-minimum-value"`
-						ComputeLatencyMaximumValue  float64 `xml:"compute-latency-maximum-value"`
-						ComputeLatencyAverageValue  float64 `xml:"compute-latency-average-value"`
-						ComputeLatencyCurrentValue  float64 `xml:"compute-latency-current-value"`
-						MateLinkLatencyMinimumValue float64 `xml:"mate-link-latency-minimum-value"`
-						MateLinkLatencyMaximumValue float64 `xml:"mate-link-latency-maximum-value"`
-						MateLinkLatencyAverageValue float64 `xml:"mate-link-latency-average-value"`
-						MateLinkLatencyCurrentValue float64 `xml:"mate-link-latency-current-value"`
-					} `xml:"health"`
-				} `xml:"system"`
-			} `xml:"show"`
-		} `xml:"rpc"`
-		ExecuteResult struct {
-			Result string `xml:"code,attr"`
-		} `xml:"execute-result"`
-	}
-
-	command := "<rpc><show><system><health/></system></show ></rpc>"
-	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
-	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape HealthSemp1", "err", err)
-		return 0
-	}
-	defer body.Close()
-	decoder := xml.NewDecoder(body)
-	var target Data
-	err = decoder.Decode(&target)
-	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml HealthSemp1", "err", err)
-		return 0
-	}
-	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
-		return 0
-	}
-
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_disk_latency_min_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.DiskLatencyMinimumValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_disk_latency_max_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.DiskLatencyMaximumValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_disk_latency_avg_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.DiskLatencyAverageValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_disk_latency_cur_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.DiskLatencyCurrentValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_compute_latency_min_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.ComputeLatencyMinimumValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_compute_latency_max_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.ComputeLatencyMaximumValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_compute_latency_avg_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.ComputeLatencyAverageValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_compute_latency_cur_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.ComputeLatencyCurrentValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_mate_link_latency_min_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.MateLinkLatencyMinimumValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_mate_link_latency_max_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.MateLinkLatencyMaximumValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_mate_link_latency_avg_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.MateLinkLatencyAverageValue/1e6, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["system_mate_link_latency_cur_seconds"], prometheus.GaugeValue, target.RPC.Show.System.Health.MateLinkLatencyCurrentValue/1e6, vmrVersion)
+	ch <- prometheus.MustNewConstMetric(metricsStd["system_redundancy_local_active"], prometheus.GaugeValue, f, mateRouterName)
 
 	return 1
 }
@@ -531,27 +512,27 @@ func (e *Exporter) getBridgeSemp1(ch chan<- prometheus.Metric) (ok float64) {
 		level.Error(e.logger).Log("command", command)
 		return 0
 	}
-	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_total_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumTotalBridgesValue, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_total_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumTotalBridgesValue, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_local_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumLocalBridgesValue, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_local_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumLocalBridgesValue, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_remote_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumRemoteBridgesValue, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_remote_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumRemoteBridgesValue, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_total_remote_bridge_subscriptions"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumTotalRemoteBridgeSubscriptions, vmrVersion)
-	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_total_remote_bridge_subscriptions"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumTotalRemoteBridgeSubscriptions, vmrVersion)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_total_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumTotalBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_total_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumTotalBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_local_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumLocalBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_local_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumLocalBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_remote_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumRemoteBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_remote_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumRemoteBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_total_remote_bridge_subscriptions"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumTotalRemoteBridgeSubscriptions)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_total_remote_bridge_subscriptions"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumTotalRemoteBridgeSubscriptions)
 	opStates := []string{"Init", "Shutdown", "NoShutdown", "Prepare", "Prepare-WaitToConnect", "Prepare-FetchingDNS", "NotReady", "NotReady-Connecting", "NotReady-Handshaking", "NotReady-WaitNext", "NotReady-WaitReuse", "NotRead-WaitBridgeVersionMismatch", "NotReady-WaitCleanup", "Ready", "Ready-Subscribing", "Ready-InSync", "NotApplicable", "Invalid"}
 	failReasons := []string{"Bridge disabled", "No remote message-vpns configured", "SMF service is disabled", "Msg Backbone is disabled", "Local message-vpn is disabled", "Active-Standby Role Mismatch", "Invalid Active-Standby Role", "Redundancy Disabled", "Not active", "Replication standby", "Remote message-vpns disabled", "Enforce-trusted-common-name but empty trust-common-name list", "SSL transport used but cipher-suite list is empty", "Authentication Scheme is Client-Certificate but no certificate is configured", "Client-Certificate Authentication Scheme used but not all Remote Message VPNs use SSL", "Basic Authentication Scheme used but Basic Client Username not configured", "Cluster Down", "Cluster Link Down", ""}
 	for _, bridge := range target.RPC.Show.Bridge.Bridges.Bridge {
 		bridgeName := bridge.BridgeName
 		vpnName := bridge.LocalVpnName
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_admin_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.AdminState, []string{"Enabled", "Disabled"}), vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_connection_establisher"], prometheus.GaugeValue, encodeMetricMulti(bridge.ConnectionEstablisher, []string{"NotApplicable", "Local", "Remote"}), vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_inbound_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.InboundOperationalState, opStates), vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_inbound_operational_failure_reason"], prometheus.GaugeValue, encodeMetricMulti(bridge.InboundOperationalFailureReason, failReasons), vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_outbound_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.OutboundOperationalState, opStates), vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_queue_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.QueueOperationalState, []string{"NotApplicable", "Bound", "Unbound"}), vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_redundancy"], prometheus.GaugeValue, encodeMetricMulti(bridge.Redundancy, []string{"NotApplicable", "auto", "primary", "backup", "static", "none"}), vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_connection_uptime_in_seconds"], prometheus.GaugeValue, bridge.ConnectionUptimeInSeconds, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_admin_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.AdminState, []string{"Enabled", "Disabled"}), vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_connection_establisher"], prometheus.GaugeValue, encodeMetricMulti(bridge.ConnectionEstablisher, []string{"NotApplicable", "Local", "Remote"}), vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_inbound_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.InboundOperationalState, opStates), vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_inbound_operational_failure_reason"], prometheus.GaugeValue, encodeMetricMulti(bridge.InboundOperationalFailureReason, failReasons), vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_outbound_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.OutboundOperationalState, opStates), vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_queue_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.QueueOperationalState, []string{"NotApplicable", "Bound", "Unbound"}), vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_redundancy"], prometheus.GaugeValue, encodeMetricMulti(bridge.Redundancy, []string{"NotApplicable", "auto", "primary", "backup", "static", "none"}), vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_connection_uptime_in_seconds"], prometheus.GaugeValue, bridge.ConnectionUptimeInSeconds, vpnName, bridgeName)
 	}
 	return 1
 }
@@ -674,42 +655,42 @@ func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 	for _, bridge := range target.RPC.Show.Bridge.Bridges.Bridge {
 		bridgeName := bridge.BridgeName
 		vpnName := bridge.LocalVpnName
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_num_subscriptions"], prometheus.GaugeValue, bridge.Client.NumSubscriptions, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_slow_subscriber"], prometheus.GaugeValue, encodeMetricBool(bridge.Client.SlowSubscriber), vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_num_subscriptions"], prometheus.GaugeValue, bridge.Client.NumSubscriptions, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_slow_subscriber"], prometheus.GaugeValue, encodeMetricBool(bridge.Client.SlowSubscriber), vpnName, bridgeName)
 
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataMessagesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataMessagesSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentMessagesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentMessagesSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentMessagesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentMessagesSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectMessagesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectMessagesSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataMessagesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataMessagesSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentMessagesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentMessagesSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentMessagesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentMessagesSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectMessagesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectMessagesSent, vpnName, bridgeName)
 
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientBytesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_bytess_sent"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientBytesSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataBytesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataBytesSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentBytesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentBytesSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentBytesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentBytesSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectBytesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectBytesSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientBytesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_bytess_sent"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientBytesSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataBytesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataBytesSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentBytesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentBytesSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentBytesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentBytesSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectBytesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectBytesSent, vpnName, bridgeName)
 
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_large_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.LargeMessagesReceived, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_denied_duplicate_clients"], prometheus.GaugeValue, bridge.Client.Stats.DeniedDuplicateClients, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_enough_space_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotEnoughSpaceMsgsSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_max_exceeded_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.MaxExceededMsgsSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_subscribe_client_not_found"], prometheus.GaugeValue, bridge.Client.Stats.SubscribeClientNotFound, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_found_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotFoundMsgsSent, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_ingress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentIngressRatePerSecond, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_egress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentEgressRatePerSecond, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_large_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.LargeMessagesReceived, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_denied_duplicate_clients"], prometheus.GaugeValue, bridge.Client.Stats.DeniedDuplicateClients, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_enough_space_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotEnoughSpaceMsgsSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_max_exceeded_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.MaxExceededMsgsSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_subscribe_client_not_found"], prometheus.GaugeValue, bridge.Client.Stats.SubscribeClientNotFound, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_found_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotFoundMsgsSent, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_ingress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentIngressRatePerSecond, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_egress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentEgressRatePerSecond, vpnName, bridgeName)
 
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_ingress_discards"], prometheus.GaugeValue, bridge.Client.Stats.IngressDiscards.TotalIngressDiscards, vmrVersion, bridgeName, vpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_egress_discards"], prometheus.GaugeValue, bridge.Client.Stats.EgressDiscards.TotalEgressDiscards, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_ingress_discards"], prometheus.GaugeValue, bridge.Client.Stats.IngressDiscards.TotalIngressDiscards, vpnName, bridgeName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_egress_discards"], prometheus.GaugeValue, bridge.Client.Stats.EgressDiscards.TotalEgressDiscards, vpnName, bridgeName)
 	}
 	return 1
 }
@@ -774,15 +755,15 @@ func (e *Exporter) getVpnStatsSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	}
 
 	for _, vpn := range target.RPC.Show.MessageVpn.Vpn {
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_connections"], prometheus.GaugeValue, vpn.Connections, vmrVersion, vpn.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_local_status"], prometheus.GaugeValue, encodeMetricMulti(vpn.LocalStatus, []string{"Down", "Up"}), vmrVersion, vpn.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_connections"], prometheus.GaugeValue, vpn.Connections, vpn.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_local_status"], prometheus.GaugeValue, encodeMetricMulti(vpn.LocalStatus, []string{"Down", "Up"}), vpn.Name)
 
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_rx_msgs_total"], prometheus.CounterValue, vpn.Stats.DataRxMsgCount, vmrVersion, vpn.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_tx_msgs_total"], prometheus.CounterValue, vpn.Stats.DataTxMsgCount, vmrVersion, vpn.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_rx_bytes_total"], prometheus.CounterValue, vpn.Stats.DataRxByteCount, vmrVersion, vpn.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_tx_bytes_total"], prometheus.CounterValue, vpn.Stats.DataTxByteCount, vmrVersion, vpn.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_rx_discarded_msgs_total"], prometheus.CounterValue, vpn.Stats.IngressDiscards.DiscardedRxMsgCount, vmrVersion, vpn.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_tx_discarded_msgs_total"], prometheus.CounterValue, vpn.Stats.EgressDiscards.DiscardedTxMsgCount, vmrVersion, vpn.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_rx_msgs_total"], prometheus.CounterValue, vpn.Stats.DataRxMsgCount, vpn.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_tx_msgs_total"], prometheus.CounterValue, vpn.Stats.DataTxMsgCount, vpn.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_rx_bytes_total"], prometheus.CounterValue, vpn.Stats.DataRxByteCount, vpn.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_tx_bytes_total"], prometheus.CounterValue, vpn.Stats.DataTxByteCount, vpn.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_rx_discarded_msgs_total"], prometheus.CounterValue, vpn.Stats.IngressDiscards.DiscardedRxMsgCount, vpn.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_tx_discarded_msgs_total"], prometheus.CounterValue, vpn.Stats.EgressDiscards.DiscardedTxMsgCount, vpn.Name)
 	}
 
 	return 1
@@ -837,10 +818,10 @@ func (e *Exporter) getConfigSyncSemp1(ch chan<- prometheus.Metric) (ok float64) 
 	}
 
 	for _, table := range target.RPC.Show.ConfigSync.Database.Local.Tables.Table {
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_type"], prometheus.GaugeValue, encodeMetricMulti(table.Type, []string{"Router", "Vpn"}), vmrVersion, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_timeinstateseconds"], prometheus.CounterValue, table.TimeInStateSeconds, vmrVersion, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave"}), vmrVersion, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_syncstate"], prometheus.GaugeValue, encodeMetricMulti(table.SyncState, []string{"Down", "Up"}), vmrVersion, table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_type"], prometheus.GaugeValue, encodeMetricMulti(table.Type, []string{"Router", "Vpn"}), table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_timeinstateseconds"], prometheus.CounterValue, table.TimeInStateSeconds, table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave", "Unknown"}), table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_syncstate"], prometheus.GaugeValue, encodeMetricMulti(table.SyncState, []string{"Down", "Up"}), table.Name)
 	}
 
 	return 1
@@ -895,10 +876,10 @@ func (e *Exporter) getConfigSyncRouterSemp1(ch chan<- prometheus.Metric) (ok flo
 	}
 
 	for _, table := range target.RPC.Show.ConfigSync.Database.Local.Tables.Table {
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_type"], prometheus.GaugeValue, encodeMetricMulti(table.Type, []string{"Router", "Vpn"}), vmrVersion, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_timeinstateseconds"], prometheus.CounterValue, table.TimeInStateSeconds, vmrVersion, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave"}), vmrVersion, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_syncstate"], prometheus.GaugeValue, encodeMetricMulti(table.SyncState, []string{"Down", "Up"}), vmrVersion, table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_type"], prometheus.GaugeValue, encodeMetricMulti(table.Type, []string{"Router", "Vpn"}), table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_timeinstateseconds"], prometheus.CounterValue, table.TimeInStateSeconds, table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave"}), table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_syncstate"], prometheus.GaugeValue, encodeMetricMulti(table.SyncState, []string{"Down", "Up"}), table.Name)
 	}
 
 	return 1
@@ -953,10 +934,10 @@ func (e *Exporter) getConfigSyncVpnSemp1(ch chan<- prometheus.Metric) (ok float6
 	}
 
 	for _, table := range target.RPC.Show.ConfigSync.Database.Local.Tables.Table {
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_type"], prometheus.GaugeValue, encodeMetricMulti(table.Type, []string{"Router", "Vpn"}), vmrVersion, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_timeinstateseconds"], prometheus.CounterValue, table.TimeInStateSeconds, vmrVersion, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave"}), vmrVersion, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_syncstate"], prometheus.GaugeValue, encodeMetricMulti(table.SyncState, []string{"Down", "Up"}), vmrVersion, table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_type"], prometheus.GaugeValue, encodeMetricMulti(table.Type, []string{"Router", "Vpn"}), table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_timeinstateseconds"], prometheus.CounterValue, table.TimeInStateSeconds, table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave"}), table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_syncstate"], prometheus.GaugeValue, encodeMetricMulti(table.SyncState, []string{"Down", "Up"}), table.Name)
 	}
 
 	return 1
@@ -1007,9 +988,9 @@ func (e *Exporter) getVpnReplicationSemp1(ch chan<- prometheus.Metric) (ok float
 	}
 
 	for _, vpn := range target.RPC.Show.MessageVpn.Replication.MessageVpns.MessageVpn {
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_replication_admin_state"], prometheus.GaugeValue, encodeMetricMulti(vpn.AdminState, []string{"shutdown", "enabled", "n/a"}), vmrVersion, vpn.VpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_replication_config_state"], prometheus.GaugeValue, encodeMetricMulti(vpn.ConfigState, []string{"standby", "active", "n/a"}), vmrVersion, vpn.VpnName)
-		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_replication_transaction_replication_mode"], prometheus.GaugeValue, encodeMetricMulti(vpn.TransactionReplicationMode, []string{"async", "sync"}), vmrVersion, vpn.VpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_replication_admin_state"], prometheus.GaugeValue, encodeMetricMulti(vpn.AdminState, []string{"shutdown", "enabled", "n/a"}), vpn.VpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_replication_config_state"], prometheus.GaugeValue, encodeMetricMulti(vpn.ConfigState, []string{"standby", "active", "n/a"}), vpn.VpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_replication_transaction_replication_mode"], prometheus.GaugeValue, encodeMetricMulti(vpn.TransactionReplicationMode, []string{"async", "sync"}), vpn.VpnName)
 	}
 
 	return 1
@@ -1085,13 +1066,13 @@ func (e *Exporter) getClientStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 		nextRequest = target.MoreCookie.RPC
 
 		for _, client := range target.RPC.Show.Client.PrimaryVirtualRouter.Client {
-			ch <- prometheus.MustNewConstMetric(metricsDet["client_rx_msgs_total"], prometheus.CounterValue, client.Stats.DataRxMsgCount, vmrVersion, client.MsgVpnName, client.ClientName, client.ClientUsername)
-			ch <- prometheus.MustNewConstMetric(metricsDet["client_tx_msgs_total"], prometheus.CounterValue, client.Stats.DataTxMsgCount, vmrVersion, client.MsgVpnName, client.ClientName, client.ClientUsername)
-			ch <- prometheus.MustNewConstMetric(metricsDet["client_rx_bytes_total"], prometheus.CounterValue, client.Stats.DataRxByteCount, vmrVersion, client.MsgVpnName, client.ClientName, client.ClientUsername)
-			ch <- prometheus.MustNewConstMetric(metricsDet["client_tx_bytes_total"], prometheus.CounterValue, client.Stats.DataTxByteCount, vmrVersion, client.MsgVpnName, client.ClientName, client.ClientUsername)
-			ch <- prometheus.MustNewConstMetric(metricsDet["client_rx_discarded_msgs_total"], prometheus.CounterValue, client.Stats.IngressDiscards.DiscardedRxMsgCount, vmrVersion, client.MsgVpnName, client.ClientName, client.ClientUsername)
-			ch <- prometheus.MustNewConstMetric(metricsDet["client_tx_discarded_msgs_total"], prometheus.CounterValue, client.Stats.EgressDiscards.DiscardedTxMsgCount, vmrVersion, client.MsgVpnName, client.ClientName, client.ClientUsername)
-			ch <- prometheus.MustNewConstMetric(metricsDet["client_slow_subscriber"], prometheus.GaugeValue, encodeMetricBool(client.SlowSubscriber), client.MsgVpnName, vmrVersion, client.ClientName, client.ClientUsername)
+			ch <- prometheus.MustNewConstMetric(metricsDet["client_rx_msgs_total"], prometheus.CounterValue, client.Stats.DataRxMsgCount, client.MsgVpnName, client.ClientName, client.ClientUsername)
+			ch <- prometheus.MustNewConstMetric(metricsDet["client_tx_msgs_total"], prometheus.CounterValue, client.Stats.DataTxMsgCount, client.MsgVpnName, client.ClientName, client.ClientUsername)
+			ch <- prometheus.MustNewConstMetric(metricsDet["client_rx_bytes_total"], prometheus.CounterValue, client.Stats.DataRxByteCount, client.MsgVpnName, client.ClientName, client.ClientUsername)
+			ch <- prometheus.MustNewConstMetric(metricsDet["client_tx_bytes_total"], prometheus.CounterValue, client.Stats.DataTxByteCount, client.MsgVpnName, client.ClientName, client.ClientUsername)
+			ch <- prometheus.MustNewConstMetric(metricsDet["client_rx_discarded_msgs_total"], prometheus.CounterValue, client.Stats.IngressDiscards.DiscardedRxMsgCount, client.MsgVpnName, client.ClientName, client.ClientUsername)
+			ch <- prometheus.MustNewConstMetric(metricsDet["client_tx_discarded_msgs_total"], prometheus.CounterValue, client.Stats.EgressDiscards.DiscardedTxMsgCount, client.MsgVpnName, client.ClientName, client.ClientUsername)
+			ch <- prometheus.MustNewConstMetric(metricsDet["client_slow_subscriber"], prometheus.GaugeValue, encodeMetricBool(client.SlowSubscriber), client.MsgVpnName, client.ClientName, client.ClientUsername)
 		}
 		body.Close()
 	}
@@ -1153,10 +1134,10 @@ func (e *Exporter) getQueueDetailSemp1(ch chan<- prometheus.Metric) (ok float64)
 		nextRequest = target.MoreCookie.RPC
 
 		for _, queue := range target.RPC.Show.Queue.Queues.Queue {
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_spool_quota_bytes"], prometheus.GaugeValue, math.Round(queue.Info.Quota*1048576.0), vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_spool_usage_bytes"], prometheus.GaugeValue, math.Round(queue.Info.Usage*1048576.0), vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_spool_usage_msgs"], prometheus.GaugeValue, queue.Info.SpooledMsgCount, vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_binds"], prometheus.GaugeValue, queue.Info.BindCount, vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_spool_quota_bytes"], prometheus.GaugeValue, math.Round(queue.Info.Quota*1048576.0), queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_spool_usage_bytes"], prometheus.GaugeValue, math.Round(queue.Info.Usage*1048576.0), queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_spool_usage_msgs"], prometheus.GaugeValue, queue.Info.SpooledMsgCount, queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_binds"], prometheus.GaugeValue, queue.Info.BindCount, queue.Info.MsgVpnName, queue.QueueName)
 		}
 		body.Close()
 	}
@@ -1226,14 +1207,14 @@ func (e *Exporter) getQueueRatesSemp1(ch chan<- prometheus.Metric) (ok float64) 
 		nextRequest = target.MoreCookie.RPC
 
 		for _, queue := range target.RPC.Show.Queue.Queues.Queue {
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_rx_msg_rate"], prometheus.GaugeValue, queue.Rates.Qendpt.RxMsgRate, vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_tx_msg_rate"], prometheus.GaugeValue, queue.Rates.Qendpt.TxMsgRate, vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_rx_byte_rate"], prometheus.GaugeValue, queue.Rates.Qendpt.RxByteRate, vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_tx_byte_rate"], prometheus.GaugeValue, queue.Rates.Qendpt.TxByteRate, vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_rx_msg_rate_avg"], prometheus.GaugeValue, queue.Rates.Qendpt.AverageRxMsgRate, vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_tx_msg_rate_avg"], prometheus.GaugeValue, queue.Rates.Qendpt.AverageTxMsgRate, vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_rx_byte_rate_avg"], prometheus.GaugeValue, queue.Rates.Qendpt.AverageRxByteRate, vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
-			ch <- prometheus.MustNewConstMetric(metricsDet["queue_tx_byte_rate_avg"], prometheus.GaugeValue, queue.Rates.Qendpt.AverageTxByteRate, vmrVersion, queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_rx_msg_rate"], prometheus.GaugeValue, queue.Rates.Qendpt.RxMsgRate, queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_tx_msg_rate"], prometheus.GaugeValue, queue.Rates.Qendpt.TxMsgRate, queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_rx_byte_rate"], prometheus.GaugeValue, queue.Rates.Qendpt.RxByteRate, queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_tx_byte_rate"], prometheus.GaugeValue, queue.Rates.Qendpt.TxByteRate, queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_rx_msg_rate_avg"], prometheus.GaugeValue, queue.Rates.Qendpt.AverageRxMsgRate, queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_tx_msg_rate_avg"], prometheus.GaugeValue, queue.Rates.Qendpt.AverageTxMsgRate, queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_rx_byte_rate_avg"], prometheus.GaugeValue, queue.Rates.Qendpt.AverageRxByteRate, queue.Info.MsgVpnName, queue.QueueName)
+			ch <- prometheus.MustNewConstMetric(metricsDet["queue_tx_byte_rate_avg"], prometheus.GaugeValue, queue.Rates.Qendpt.AverageTxByteRate, queue.Info.MsgVpnName, queue.QueueName)
 		}
 		body.Close()
 	}
@@ -1388,13 +1369,11 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	var up float64 = 1
 
-	// check version first in any case
-	if up > 0 {
-		up = e.getVersionSemp1(ch)
-	}
-
 	switch e.config.scope {
 	case scopeBrokerStandard:
+		if up > 0 {
+			up = e.getVersionSemp1(ch)
+		}
 		if up > 0 {
 			up = e.getHealthSemp1(ch)
 		}
@@ -1586,8 +1565,6 @@ func main() {
 	// Test scrape to check if broker can be accessed. If it fails it prints a warn to the log file.
 	// Note that failure is not fatal, as broker might not have started up yet.
 	conf.timeout, _ = time.ParseDuration("2s") // Don't delay startup too much
-	exporterCheck := NewExporter(logger, conf)
-	exporterCheck.checkBrokerAccess()
 
 	// Configure the endpoints and start the server
 	http.Handle("/metrics", promhttp.Handler())
@@ -1610,10 +1587,10 @@ func main() {
              <p><a href='` + "/solace-std" + `'>Solace Standard Metrics (System and VPN)</a></p>
              <p><a href='` + "/solace-det" + `'>Solace Detailed Metrics (Client and Queue)</a></p>
 						 <p><a href='` + "/solace-broker-std" + `'>Solace Broker only Standard Metrics (System)</a></p>
-             <p><a href='` + "/solace-vpn-std" + `'>Solace Vpn only Standard Metrics (VPN)</a></p>
 						 <p><a href='` + "/solace-broker-stats" + `'>Solace Broker only Statistics (System)</a></p>
-             <p><a href='` + "/solace-vpn-stats" + `'>Solace Vpn only Statistics (VPN)</a></p>
 						 <p><a href='` + "/solace-broker-det" + `'>Solace Broker only Detailed Metrics (System)</a></p>
+             <p><a href='` + "/solace-vpn-std" + `'>Solace Vpn only Standard Metrics (VPN)</a></p>
+             <p><a href='` + "/solace-vpn-stats" + `'>Solace Vpn only Statistics (VPN)</a></p>
              <p><a href='` + "/solace-vpn-det" + `'>Solace Vpn only Detailed Metrics (VPN)</a></p>
              </body>
              </html>`))

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -87,13 +87,13 @@ var metricsStd = metrics{
 	"system_mate_link_latency_cur_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_cur_seconds", "Current mate link latency.", nil, nil),
 
 	// config sync
-	"configsync_table_type":               prometheus.NewDesc(namespace+"_"+"configsync_table_type", "Config Sync Resource Type", variableLabelsConfigSyncTable, nil),
+	"configsync_table_type":               prometheus.NewDesc(namespace+"_"+"configsync_table_type", "Config Sync Resource Type (0-Router, 1-Vpn)", variableLabelsConfigSyncTable, nil),
 	"configsync_table_timeinstateseconds": prometheus.NewDesc(namespace+"_"+"configsync_table_timeinstateseconds", "Config Sync Time in State", variableLabelsConfigSyncTable, nil),
-	"configsync_table_ownership":          prometheus.NewDesc(namespace+"_"+"configsync_table_ownership", "Config Sync Ownership", variableLabelsConfigSyncTable, nil),
-	"configsync_table_syncstate":          prometheus.NewDesc(namespace+"_"+"configsync_table_syncstate", "Config Sync State", variableLabelsConfigSyncTable, nil),
+	"configsync_table_ownership":          prometheus.NewDesc(namespace+"_"+"configsync_table_ownership", "Config Sync Ownership (0-Master, 1-Slave, 2-Unknown)", variableLabelsConfigSyncTable, nil),
+	"configsync_table_syncstate":          prometheus.NewDesc(namespace+"_"+"configsync_table_syncstate", "Config Sync State (0-Down, 1-Up)", variableLabelsConfigSyncTable, nil),
 
 	// vpn
-	"vpn_local_status":                             prometheus.NewDesc(namespace+"_"+"vpn_local_status", "Local status (0=Down, 1=Up).", variableLabelsVpn, nil),
+	"vpn_local_status":                             prometheus.NewDesc(namespace+"_"+"vpn_local_status", "Local status (0=Down, 1=Up)", variableLabelsVpn, nil),
 	"vpn_connections":                              prometheus.NewDesc(namespace+"_"+"vpn_connections", "Number of connections.", variableLabelsVpn, nil),
 	"vpn_rx_msgs_total":                            prometheus.NewDesc(namespace+"_"+"vpn_rx_msgs_total", "Number of received messages.", variableLabelsVpn, nil),
 	"vpn_tx_msgs_total":                            prometheus.NewDesc(namespace+"_"+"vpn_tx_msgs_total", "Number of transmitted messages.", variableLabelsVpn, nil),
@@ -101,9 +101,9 @@ var metricsStd = metrics{
 	"vpn_tx_bytes_total":                           prometheus.NewDesc(namespace+"_"+"vpn_tx_bytes_total", "Number of transmitted bytes.", variableLabelsVpn, nil),
 	"vpn_rx_discarded_msgs_total":                  prometheus.NewDesc(namespace+"_"+"vpn_rx_discarded_msgs_total", "Number of discarded received messages.", variableLabelsVpn, nil),
 	"vpn_tx_discarded_msgs_total":                  prometheus.NewDesc(namespace+"_"+"vpn_tx_discarded_msgs_total", "Number of discarded transmitted messages.", variableLabelsVpn, nil),
-	"vpn_replication_admin_state":                  prometheus.NewDesc(namespace+"_"+"vpn_replication_admin_state", "Replication Admin Status", variableLabelsVpn, nil),
-	"vpn_replication_config_state":                 prometheus.NewDesc(namespace+"_"+"vpn_replication_config_state", "Replication Config Status", variableLabelsVpn, nil),
-	"vpn_replication_transaction_replication_mode": prometheus.NewDesc(namespace+"_"+"vpn_replication_transaction_replication_mode", "Replication Tx Replication Mode", variableLabelsVpn, nil),
+	"vpn_replication_admin_state":                  prometheus.NewDesc(namespace+"_"+"vpn_replication_admin_state", "Replication Admin Status (0-shutdown, 1-enabled, 2-n/a)", variableLabelsVpn, nil),
+	"vpn_replication_config_state":                 prometheus.NewDesc(namespace+"_"+"vpn_replication_config_state", "Replication Config Status (0-standby, 1-active, 2-n/a)", variableLabelsVpn, nil),
+	"vpn_replication_transaction_replication_mode": prometheus.NewDesc(namespace+"_"+"vpn_replication_transaction_replication_mode", "Replication Tx Replication Mode (0-async, 1-sync)", variableLabelsVpn, nil),
 
 	//bridges
 	"bridges_num_total_bridges":                         prometheus.NewDesc(namespace+"_"+"bridges_num_total_bridges", "Number of Bridges", nil, nil),
@@ -117,12 +117,12 @@ var metricsStd = metrics{
 
 	// bridge
 	"bridge_admin_state":                            prometheus.NewDesc(namespace+"_"+"bridge_admin_state", "Bridge Administrative State (0-Enabled 1-Disabled)", variableLabelsBridge, nil),
-	"bridge_connection_establisher":                 prometheus.NewDesc(namespace+"_"+"bridge_connection_establisher", "Connection Establisher", variableLabelsBridge, nil),
-	"bridge_inbound_operational_state":              prometheus.NewDesc(namespace+"_"+"bridge_inbound_operational_state", "Inbound Ops State", variableLabelsBridge, nil),
-	"bridge_inbound_operational_failure_reason":     prometheus.NewDesc(namespace+"_"+"bridge_inbound_operational_failure_reason", "Inbound Ops Failure Reason", variableLabelsBridge, nil),
-	"bridge_outbound_operational_state":             prometheus.NewDesc(namespace+"_"+"bridge_outbound_operational_state", "Outbound Ops State", variableLabelsBridge, nil),
-	"bridge_queue_operational_state":                prometheus.NewDesc(namespace+"_"+"bridge_queue_operational_state", "Queue Ops State", variableLabelsBridge, nil),
-	"bridge_redundancy":                             prometheus.NewDesc(namespace+"_"+"bridge_redundancy", "Redundancy", variableLabelsBridge, nil),
+	"bridge_connection_establisher":                 prometheus.NewDesc(namespace+"_"+"bridge_connection_establisher", "Connection Establisher (0-NotApplicable, 1-Local, 2-Remote)", variableLabelsBridge, nil),
+	"bridge_inbound_operational_state":              prometheus.NewDesc(namespace+"_"+"bridge_inbound_operational_state", "Inbound Ops State (0-Init, 1-Shutdown, 2-NoShutdown, 3-Prepare, 4-Prepare-WaitToConnect, 5-Prepare-FetchingDNS, 6-NotReady, 7-NotReady-Connecting, 8-NotReady-Handshaking, 9-NotReady-WaitNext, 10-NotReady-WaitReuse, 11-NotRead-WaitBridgeVersionMismatch, 12-NotReady-WaitCleanup, 13-Ready, 14-Ready-Subscribing, 15-Ready-InSync, 16-NotApplicable, 17-Invalid)", variableLabelsBridge, nil),
+	"bridge_inbound_operational_failure_reason":     prometheus.NewDesc(namespace+"_"+"bridge_inbound_operational_failure_reason", "Inbound Ops Failure Reason (various very long codes)", variableLabelsBridge, nil),
+	"bridge_outbound_operational_state":             prometheus.NewDesc(namespace+"_"+"bridge_outbound_operational_state", "Outbound Ops State (0-Init, 1-Shutdown, 2-NoShutdown, 3-Prepare, 4-Prepare-WaitToConnect, 5-Prepare-FetchingDNS, 6-NotReady, 7-NotReady-Connecting, 8-NotReady-Handshaking, 9-NotReady-WaitNext, 10-NotReady-WaitReuse, 11-NotRead-WaitBridgeVersionMismatch, 12-NotReady-WaitCleanup, 13-Ready, 14-Ready-Subscribing, 15-Ready-InSync, 16-NotApplicable, 17-Invalid)", variableLabelsBridge, nil),
+	"bridge_queue_operational_state":                prometheus.NewDesc(namespace+"_"+"bridge_queue_operational_state", "Queue Ops State (0-NotApplicable, 1-Bound, 2-Unbound)", variableLabelsBridge, nil),
+	"bridge_redundancy":                             prometheus.NewDesc(namespace+"_"+"bridge_redundancy", "Bridge Redundancy (0-NotApplicable, 1-auto, 2-primary, 3-backup, 4-static, 5-none)", variableLabelsBridge, nil),
 	"bridge_connection_uptime_in_seconds":           prometheus.NewDesc(namespace+"_"+"bridge_connection_uptime_in_seconds", "Connection Uptime (s)", variableLabelsBridge, nil),
 	"bridge_client_num_subscriptions":               prometheus.NewDesc(namespace+"_"+"bridge_client_num_subscriptions", "Bridge Client Subscription", variableLabelsBridge, nil),
 	"bridge_client_slow_subscriber":                 prometheus.NewDesc(namespace+"_"+"bridge_client_slow_subscriber", "Bridge Slow Subscriber", variableLabelsBridge, nil),
@@ -878,7 +878,7 @@ func (e *Exporter) getConfigSyncRouterSemp1(ch chan<- prometheus.Metric) (ok flo
 	for _, table := range target.RPC.Show.ConfigSync.Database.Local.Tables.Table {
 		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_type"], prometheus.GaugeValue, encodeMetricMulti(table.Type, []string{"Router", "Vpn"}), table.Name)
 		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_timeinstateseconds"], prometheus.CounterValue, table.TimeInStateSeconds, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave"}), table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave", "Unknown"}), table.Name)
 		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_syncstate"], prometheus.GaugeValue, encodeMetricMulti(table.SyncState, []string{"Down", "Up"}), table.Name)
 	}
 
@@ -936,7 +936,7 @@ func (e *Exporter) getConfigSyncVpnSemp1(ch chan<- prometheus.Metric) (ok float6
 	for _, table := range target.RPC.Show.ConfigSync.Database.Local.Tables.Table {
 		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_type"], prometheus.GaugeValue, encodeMetricMulti(table.Type, []string{"Router", "Vpn"}), table.Name)
 		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_timeinstateseconds"], prometheus.CounterValue, table.TimeInStateSeconds, table.Name)
-		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave"}), table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave", "Unknown"}), table.Name)
 		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_syncstate"], prometheus.GaugeValue, encodeMetricMulti(table.SyncState, []string{"Down", "Up"}), table.Name)
 	}
 

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -45,7 +45,7 @@ type metrics map[string]*prometheus.Desc
 
 var (
 	vmrVersion            = string("undefined")
-	solaceExporterVersion = float64(1001006)
+	solaceExporterVersion = float64(1001007)
 
 	variableLabelsVersion         = []string{"vmrVersion"}
 	variableExporterVersion       = []string{"vmrVersion"}
@@ -122,18 +122,42 @@ var metricsStd = metrics{
 	"bridge_redundancy":                         prometheus.NewDesc(namespace+"_"+"bridge_redundancy", "Redundancy", variableLabelsBridge, nil),
 	"bridge_connection_uptime_in_seconds":       prometheus.NewDesc(namespace+"_"+"bridge_connection_uptime_in_seconds", "Connection Uptime (s)", variableLabelsBridge, nil),
 
-	"bridge_client_num_subscriptions":        prometheus.NewDesc(namespace+"_"+"bridge_client_num_subscriptions", "Bridge Client Subscription", variableLabelsBridge, nil),
-	"bridge_client_slow_subscriber":          prometheus.NewDesc(namespace+"_"+"bridge_client_slow_subscriber", "Bridge Slow Subscriber", variableLabelsBridge, nil),
-	"bridge_total_client_messages_received":  prometheus.NewDesc(namespace+"_"+"bridge_total_client_messages_received", "Bridge Total Client Msg Received", variableLabelsBridge, nil),
-	"bridge_total_client_messages_sent":      prometheus.NewDesc(namespace+"_"+"bridge_total_client_messages_sent", "Bridge Client Messages sent", variableLabelsBridge, nil),
-	"bridge_denied_duplicate_clients":        prometheus.NewDesc(namespace+"_"+"bridge_denied_duplicate_clients", "Bridge Denied Duplicate Clients", variableLabelsBridge, nil),
-	"bridge_not_enough_space_msgs_sent":      prometheus.NewDesc(namespace+"_"+"bridge_not_enough_space_msgs_sent", "Bridge Not Enough Space Msgs sent", variableLabelsBridge, nil),
-	"bridge_max_exceeded_msgs_sent":          prometheus.NewDesc(namespace+"_"+"bridge_max_exceeded_msgs_sent", "Bridge Max Exceeded Msgs sent", variableLabelsBridge, nil),
-	"bridge_not_found_msgs_sent":             prometheus.NewDesc(namespace+"_"+"bridge_not_found_msgs_sent", "Bridge Not Found Msgs sent", variableLabelsBridge, nil),
-	"bridge_current_ingress_rate_per_second": prometheus.NewDesc(namespace+"_"+"bridge_current_ingress_rate_per_second", "Bridge current ingress rate (s)", variableLabelsBridge, nil),
-	"bridge_current_egress_rate_per_second":  prometheus.NewDesc(namespace+"_"+"bridge_current_egress_rate_per_second", "Bridge current egress rate (s)", variableLabelsBridge, nil),
-	"bridge_add_by_subscription_manager":     prometheus.NewDesc(namespace+"_"+"bridge_add_by_subscription_manager", "Add by subscription manager", variableLabelsBridge, nil),
-	"bridge_remove_by_subscription_manager":  prometheus.NewDesc(namespace+"_"+"bridge_remove_by_subscription_manager", "Remove by subscription manager", variableLabelsBridge, nil),
+	"bridge_client_num_subscriptions": prometheus.NewDesc(namespace+"_"+"bridge_client_num_subscriptions", "Bridge Client Subscription", variableLabelsBridge, nil),
+	"bridge_client_slow_subscriber":   prometheus.NewDesc(namespace+"_"+"bridge_client_slow_subscriber", "Bridge Slow Subscriber", variableLabelsBridge, nil),
+
+	"bridge_total_client_messages_received":         prometheus.NewDesc(namespace+"_"+"bridge_total_client_messages_received", "Bridge Total Client Messages Received", variableLabelsBridge, nil),
+	"bridge_total_client_messages_sent":             prometheus.NewDesc(namespace+"_"+"bridge_total_client_messages_sent", "Bridge Total Client Messages sent", variableLabelsBridge, nil),
+	"bridge_client_data_messages_received":          prometheus.NewDesc(namespace+"_"+"bridge_client_data_messages_received", "Bridge Client Data Msgs Received", variableLabelsBridge, nil),
+	"bridge_client_data_messages_sent":              prometheus.NewDesc(namespace+"_"+"bridge_client_data_messages_sent", "Bridge Client Data Msgs Sent", variableLabelsBridge, nil),
+	"bridge_client_persistent_messages_received":    prometheus.NewDesc(namespace+"_"+"bridge_client_persistent_messages_received", "Bridge Client Persistent Msgs Received", variableLabelsBridge, nil),
+	"bridge_client_persistent_messages_sent":        prometheus.NewDesc(namespace+"_"+"bridge_client_persistent_messages_sent", "Bridge Client Persistent Msgs Sent", variableLabelsBridge, nil),
+	"bridge_client_nonpersistent_messages_received": prometheus.NewDesc(namespace+"_"+"bridge_client_nonpersistent_messages_received", "Bridge Client Non-Persistent Msgs Received", variableLabelsBridge, nil),
+	"bridge_client_nonpersistent_messages_sent":     prometheus.NewDesc(namespace+"_"+"bridge_client_nonpersistent_messages_sent", "Bridge Client Non-Persistent Msgs Sent", variableLabelsBridge, nil),
+	"bridge_client_direct_messages_received":        prometheus.NewDesc(namespace+"_"+"bridge_client_direct_messages_received", "Bridge Client Direct Msgs Received", variableLabelsBridge, nil),
+	"bridge_client_direct_messages_sent":            prometheus.NewDesc(namespace+"_"+"bridge_client_direct_messages_sent", "Bridge Client Direct Msgs Sent", variableLabelsBridge, nil),
+
+	"bridge_total_client_bytes_received":         prometheus.NewDesc(namespace+"_"+"bridge_total_client_bytes_received", "Bridge Total Client Bytes Received", variableLabelsBridge, nil),
+	"bridge_total_client_bytess_sent":            prometheus.NewDesc(namespace+"_"+"bridge_total_client_bytess_sent", "Bridge Total Client Bytes sent", variableLabelsBridge, nil),
+	"bridge_client_data_bytes_received":          prometheus.NewDesc(namespace+"_"+"bridge_client_data_bytes_received", "Bridge Client Data Bytes Received", variableLabelsBridge, nil),
+	"bridge_client_data_bytes_sent":              prometheus.NewDesc(namespace+"_"+"bridge_client_data_bytes_sent", "Bridge Client Data Bytes Sent", variableLabelsBridge, nil),
+	"bridge_client_persistent_bytes_received":    prometheus.NewDesc(namespace+"_"+"bridge_client_persistent_bytes_received", "Bridge Client Persistent Bytes Received", variableLabelsBridge, nil),
+	"bridge_client_persistent_bytes_sent":        prometheus.NewDesc(namespace+"_"+"bridge_client_persistent_bytes_sent", "Bridge Client Persistent Bytes Sent", variableLabelsBridge, nil),
+	"bridge_client_nonpersistent_bytes_received": prometheus.NewDesc(namespace+"_"+"bridge_client_nonpersistent_bytes_received", "Bridge Client Non-Persistent Bytes Received", variableLabelsBridge, nil),
+	"bridge_client_nonpersistent_bytes_sent":     prometheus.NewDesc(namespace+"_"+"bridge_client_nonpersistent_bytes_sent", "Bridge Client Non-Persistent Bytes Sent", variableLabelsBridge, nil),
+	"bridge_client_direct_bytes_received":        prometheus.NewDesc(namespace+"_"+"bridge_client_direct_bytes_received", "Bridge Client Direct Bytes Received", variableLabelsBridge, nil),
+	"bridge_client_direct_bytes_sent":            prometheus.NewDesc(namespace+"_"+"bridge_client_direct_bytes_sent", "Bridge Client Direct Bytes Sent", variableLabelsBridge, nil),
+
+	"bridge_client_large_messages_received":  prometheus.NewDesc(namespace+"_"+"bridge_client_large_messages_received", "Bridge Client Large Messages received", variableLabelsBridge, nil),
+	"bridge_denied_duplicate_clients":        prometheus.NewDesc(namespace+"_"+"bridge_denied_duplicate_clients", "Bridge Deneid Duplicate Clients", variableLabelsBridge, nil),
+	"bridge_not_enough_space_msgs_sent":      prometheus.NewDesc(namespace+"_"+"bridge_not_enough_space_msgs_sent", "Bridge Not Enough Space Messages Sent", variableLabelsBridge, nil),
+	"bridge_max_exceeded_msgs_sent":          prometheus.NewDesc(namespace+"_"+"bridge_max_exceeded_msgs_sent", "Bridge Max Exceeded Messages Sent", variableLabelsBridge, nil),
+	"bridge_subscribe_client_not_found":      prometheus.NewDesc(namespace+"_"+"bridge_subscribe_client_not_found", "Bridge Subscriber Client Not Found", variableLabelsBridge, nil),
+	"bridge_not_found_msgs_sent":             prometheus.NewDesc(namespace+"_"+"bridge_not_found_msgs_sent", "Bridge Not Found Messages Sent", variableLabelsBridge, nil),
+	"bridge_current_ingress_rate_per_second": prometheus.NewDesc(namespace+"_"+"bridge_current_ingress_rate_per_second", "Current Ingress Rate / s", variableLabelsBridge, nil),
+	"bridge_current_egress_rate_per_second":  prometheus.NewDesc(namespace+"_"+"bridge_current_egress_rate_per_second", "Current Egress Rate / s", variableLabelsBridge, nil),
+
+	"bridge_total_ingress_discards": prometheus.NewDesc(namespace+"_"+"bridge_total_ingress_discards", "Total Ingress Discards", variableLabelsBridge, nil),
+	"bridge_total_egress_discards":  prometheus.NewDesc(namespace+"_"+"bridge_total_egress_discards", "Total Egress Discards", variableLabelsBridge, nil),
 }
 
 var metricsDet = metrics{
@@ -660,12 +684,33 @@ func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 								Name             string  `xml:"name"`
 								NumSubscriptions float64 `xml:"num-subscriptions"`
 								ClientId         float64 `xml:"client-id"`
-								MessageVpn       float64 `xml:"message-vpn"`
+								MessageVpn       string  `xml:"message-vpn"`
 								SlowSubscriber   bool    `xml:"slow-subscriber"`
 								ClientUsername   string  `xml:"client-username"`
 								Stats            struct {
-									TotalClientMessagesReceived float64 `xml:"total-client-messages-received"`
-									TotalClientMessagesSent     float64 `xml:"total-client-messages-sent"`
+									TotalClientMessagesReceived         float64 `xml:"total-client-messages-received"`
+									TotalClientMessagesSent             float64 `xml:"total-client-messages-sent"`
+									ClientDataMessagesReceived          float64 `xml:"client-data-messages-received"`
+									ClientDataMessagesSent              float64 `xml:"client-data-messages-sent"`
+									ClientPersistentMessagesReceived    float64 `xml:"client-persistent-messages-received"`
+									ClientPersistentMessagesSent        float64 `xml:"client-persistent-messages-sent"`
+									ClientNonPersistentMessagesReceived float64 `xml:"client-non-persistent-messages-received"`
+									ClientNonPersistentMessagesSent     float64 `xml:"client-non-persistent-messages-sent"`
+									ClientDirectMessagesReceived        float64 `xml:"client-direct-messages-received"`
+									ClientDirectMessagesSent            float64 `xml:"client-direct-messages-sent"`
+
+									TotalClientBytesReceived         float64 `xml:"total-client-bytes-received"`
+									TotalClientBytesSent             float64 `xml:"total-client-bytes-sent"`
+									ClientDataBytesReceived          float64 `xml:"client-data-bytes-received"`
+									ClientDataBytesSent              float64 `xml:"client-data-bytes-sent"`
+									ClientPersistentBytesReceived    float64 `xml:"client-persistent-bytes-received"`
+									ClientPersistentBytesSent        float64 `xml:"client-persistent-bytes-sent"`
+									ClientNonPersistentBytesReceived float64 `xml:"client-non-persistent-bytes-received"`
+									ClientNonPersistentBytesSent     float64 `xml:"client-non-persistent-bytes-sent"`
+									ClientDirectBytesReceived        float64 `xml:"client-direct-bytes-received"`
+									ClientDirectBytesSent            float64 `xml:"client-direct-bytes-sent"`
+
+									LargeMessagesReceived       float64 `xml:"large-messages-received"`
 									DeniedDuplicateClients      float64 `xml:"denied-duplicate-clients"`
 									NotEnoughSpaceMsgsSent      float64 `xml:"not-enough-space-msgs-sent"`
 									MaxExceededMsgsSent         float64 `xml:"max-exceeded-msgs-sent"`
@@ -673,12 +718,36 @@ func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 									NotFoundMsgsSent            float64 `xml:"not-found-msgs-sent"`
 									CurrentIngressRatePerSecond float64 `xml:"current-ingress-rate-per-second"`
 									CurrentEgressRatePerSecond  float64 `xml:"current-egress-rate-per-second"`
-									ManagedSubscriptions        struct {
+									IngressDiscards             struct {
+										TotalIngressDiscards       float64 `xml:"total-ingress-discards"`
+										NoSubscriptionMatch        float64 `xml:"no-subscription-match"`
+										TopicParseError            float64 `xml:"topic-parse-error"`
+										ParseError                 float64 `xml:"parse-error"`
+										MsgTooBig                  float64 `xml:"msg-too-big"`
+										TtlExceeded                float64 `xml:"ttl-exceeded"`
+										WebParseError              float64 `xml:"web-parse-error"`
+										PublishTopicAcl            float64 `xml:"publish-topic-acl"`
+										MsgSpoolDiscards           float64 `xml:"msg-spool-discards"`
+										MessagePromotionCongestion float64 `xml:"message-promotion-congestion"`
+										MessageSpoolCongestion     float64 `xml:"message-spool-congestion"`
+									} `xml:"ingress-discards"`
+									EgressDiscards struct {
+										TotalEgressDiscards        float64 `xml:"total-egress-discards"`
+										TransmitCongestion         float64 `xml:"transmit-congestion"`
+										CompressionCongestion      float64 `xml:"compression-congestion"`
+										MessageElided              float64 `xml:"message-elided"`
+										TtlExceeded                float64 `xml:"ttl-exceeded"`
+										PayloadCouldNotBeFormatted float64 `xml:"payload-could-not-be-formatted"`
+										MessagePromotionCongestion float64 `xml:"message-promotion-congestion"`
+										MessageSpoolCongestion     float64 `xml:"message-spool-congestion"`
+										ClientNotConnected         float64 `xml:"client-not-connected"`
+									} `xml:"egress-discards"`
+									ManagedSubscriptions struct {
 										AddBySubscriptionManager    float64 `xml:"add-by-subscription-manager"`
 										RemoveBySubscriptionManager float64 `xml:"remove-by-subscription-manager"`
 									} `xml:"managed-subscriptions"`
 								} `xml:"stats"`
-							} `xml:"client>."`
+							} `xml:"client"`
 						} `xml:"bridge"`
 					} `xml:"bridges"`
 				} `xml:"bridge"`
@@ -710,22 +779,45 @@ func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 	for _, bridge := range target.RPC.Show.Bridge.Bridges.Bridge {
 		bridgeName := bridge.BridgeName
 		vpnName := bridge.LocalVpnName
-		// check if this element is available in response, skip in case bridge down. In case up, assume the remaining child elements exist as well
-		metric, _ := prometheus.NewConstMetric(metricsStd["bridge_client_num_subscriptions"], prometheus.GaugeValue, bridge.Client.NumSubscriptions, vmrVersion, bridgeName, vpnName)
-		if metric != nil {
-			ch <- metric
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_slow_subscriber"], prometheus.GaugeValue, encodeMetricBool(bridge.Client.SlowSubscriber), vmrVersion, bridgeName, vpnName)
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesReceived, vmrVersion, bridgeName, vpnName)
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesSent, vmrVersion, bridgeName, vpnName)
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_denied_duplicate_clients"], prometheus.GaugeValue, bridge.Client.Stats.DeniedDuplicateClients, vmrVersion, bridgeName, vpnName)
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_enough_space_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotEnoughSpaceMsgsSent, vmrVersion, bridgeName, vpnName)
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_max_exceeded_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.MaxExceededMsgsSent, vmrVersion, bridgeName, vpnName)
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_found_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotFoundMsgsSent, vmrVersion, bridgeName, vpnName)
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_ingress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentIngressRatePerSecond, vmrVersion, bridgeName, vpnName)
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_egress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentEgressRatePerSecond, vmrVersion, bridgeName, vpnName)
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_add_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.AddBySubscriptionManager, vmrVersion, bridgeName, vpnName)
-			ch <- prometheus.MustNewConstMetric(metricsStd["bridge_remove_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.RemoveBySubscriptionManager, vmrVersion, bridgeName, vpnName)
-		}
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_num_subscriptions"], prometheus.GaugeValue, bridge.Client.NumSubscriptions, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_slow_subscriber"], prometheus.GaugeValue, encodeMetricBool(bridge.Client.SlowSubscriber), vmrVersion, bridgeName, vpnName)
+
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataMessagesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataMessagesSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentMessagesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentMessagesSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentMessagesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentMessagesSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectMessagesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectMessagesSent, vmrVersion, bridgeName, vpnName)
+
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientBytesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_bytess_sent"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientBytesSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataBytesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_data_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDataBytesSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentBytesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_persistent_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientPersistentBytesSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentBytesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_nonpersistent_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientNonPersistentBytesSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_bytes_received"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectBytesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_direct_bytes_sent"], prometheus.GaugeValue, bridge.Client.Stats.ClientDirectBytesSent, vmrVersion, bridgeName, vpnName)
+
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_large_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.LargeMessagesReceived, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_denied_duplicate_clients"], prometheus.GaugeValue, bridge.Client.Stats.DeniedDuplicateClients, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_enough_space_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotEnoughSpaceMsgsSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_max_exceeded_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.MaxExceededMsgsSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_subscribe_client_not_found"], prometheus.GaugeValue, bridge.Client.Stats.SubscribeClientNotFound, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_found_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotFoundMsgsSent, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_ingress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentIngressRatePerSecond, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_egress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentEgressRatePerSecond, vmrVersion, bridgeName, vpnName)
+
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_ingress_discards"], prometheus.GaugeValue, bridge.Client.Stats.IngressDiscards.TotalIngressDiscards, vmrVersion, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_egress_discards"], prometheus.GaugeValue, bridge.Client.Stats.EgressDiscards.TotalEgressDiscards, vmrVersion, bridgeName, vpnName)
+		//
+		//		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_add_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.AddBySubscriptionManager, vmrVersion, bridgeName, vpnName)
+		//		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_remove_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.RemoveBySubscriptionManager, vmrVersion, bridgeName, vpnName)
 	}
 	return 1
 }

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -44,7 +44,7 @@ const (
 type metrics map[string]*prometheus.Desc
 
 var (
-	solaceExporterVersion = float64(1002001)
+	solaceExporterVersion = float64(1002002)
 
 	variableLabelsRedundancy      = []string{"mate_name"}
 	variableLabelsVpn             = []string{"vpn_name"}
@@ -1421,9 +1421,6 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			up = e.getQueueDetailSemp1(ch)
 		}
 	default:
-		if up > 0 {
-			up = e.getVersionSemp1(ch)
-		}
 		if e.config.details {
 			if up > 0 {
 				up = e.getClientStatsSemp1(ch)
@@ -1435,6 +1432,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 				up = e.getQueueRatesSemp1(ch)
 			}
 		} else { // Basic
+			if up > 0 {
+				up = e.getVersionSemp1(ch)
+			}
 			if up > 0 && e.config.redundancy {
 				up = e.getRedundancySemp1(ch)
 			}
@@ -1459,8 +1459,8 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			if up > 0 {
 				up = e.getBridgeStatsSemp1(ch)
 			}
+			ch <- prometheus.MustNewConstMetric(solaceUp, prometheus.GaugeValue, up)
 		}
-		ch <- prometheus.MustNewConstMetric(solaceUp, prometheus.GaugeValue, up)
 	}
 }
 

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -43,10 +43,12 @@ const (
 type metrics map[string]*prometheus.Desc
 
 var (
-	variableLabelsVpn       = []string{"vpn_name"}
-	variableLabelsVpnClient = []string{"vpn_name", "client_name", "client_username"}
-	variableLabelsVpnQueue  = []string{"vpn_name", "queue_name"}
-	solaceUp                = prometheus.NewDesc(namespace+"_"+"up", "Was the last scrape of Solace broker successful.", nil, nil)
+	variableLabelsVpn             = []string{"vpn_name"}
+	variableLabelsVpnClient       = []string{"vpn_name", "client_name", "client_username"}
+	variableLabelsVpnQueue        = []string{"vpn_name", "queue_name"}
+	variableLabelsBridge          = []string{"bridge_name", "vpn_name"}
+	variableLabelsConfigSyncTable = []string{"table_name"}
+	solaceUp                      = prometheus.NewDesc(namespace+"_"+"up", "Was the last scrape of Solace broker successful.", nil, nil)
 )
 
 var metricsStd = metrics{
@@ -71,6 +73,11 @@ var metricsStd = metrics{
 	"system_mate_link_latency_avg_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_avg_seconds", "Average mate link latency.", nil, nil),
 	"system_mate_link_latency_cur_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_cur_seconds", "Current mate link latency.", nil, nil),
 
+	"configsync_table_type":               prometheus.NewDesc(namespace+"_"+"configsync_table_type", "Config Sync Resource Type", variableLabelsConfigSyncTable, nil),
+	"configsync_table_timeinstateseconds": prometheus.NewDesc(namespace+"_"+"configsync_table_timeinstateseconds", "Config Sync Time in State", variableLabelsConfigSyncTable, nil),
+	"configsync_table_ownership":          prometheus.NewDesc(namespace+"_"+"configsync_table_ownership", "Config Sync Ownership", variableLabelsConfigSyncTable, nil),
+	"configsync_table_syncstate":          prometheus.NewDesc(namespace+"_"+"configsync_table_syncstate", "Config Sync State", variableLabelsConfigSyncTable, nil),
+
 	"vpn_local_status":            prometheus.NewDesc(namespace+"_"+"vpn_local_status", "Local status (0=Down, 1=Up).", variableLabelsVpn, nil),
 	"vpn_connections":             prometheus.NewDesc(namespace+"_"+"vpn_connections", "Number of connections.", variableLabelsVpn, nil),
 	"vpn_rx_msgs_total":           prometheus.NewDesc(namespace+"_"+"vpn_rx_msgs_total", "Number of received messages.", variableLabelsVpn, nil),
@@ -79,6 +86,40 @@ var metricsStd = metrics{
 	"vpn_tx_bytes_total":          prometheus.NewDesc(namespace+"_"+"vpn_tx_bytes_total", "Number of transmitted bytes.", variableLabelsVpn, nil),
 	"vpn_rx_discarded_msgs_total": prometheus.NewDesc(namespace+"_"+"vpn_rx_discarded_msgs_total", "Number of discarded received messages.", variableLabelsVpn, nil),
 	"vpn_tx_discarded_msgs_total": prometheus.NewDesc(namespace+"_"+"vpn_tx_discarded_msgs_total", "Number of discarded transmitted messages.", variableLabelsVpn, nil),
+
+	"vpn_replication_admin_state":                  prometheus.NewDesc(namespace+"_"+"vpn_replication_admin_state", "Replication Admin Status", variableLabelsVpn, nil),
+	"vpn_replication_config_state":                 prometheus.NewDesc(namespace+"_"+"vpn_replication_config_state", "Replication Config Status", variableLabelsVpn, nil),
+	"vpn_replication_transaction_replication_mode": prometheus.NewDesc(namespace+"_"+"vpn_replication_transaction_replication_mode", "Replication Tx Replication Mode", variableLabelsVpn, nil),
+
+	"bridges_num_total_bridges":                         prometheus.NewDesc(namespace+"_"+"bridges_num_total_bridges", "Number of Bridges", nil, nil),
+	"bridges_max_num_total_bridges":                     prometheus.NewDesc(namespace+"_"+"bridges_max_num_total_bridges", "Max number of Bridges", nil, nil),
+	"bridges_num_local_bridges":                         prometheus.NewDesc(namespace+"_"+"bridges_num_local_bridges", "Number of Local Bridges", nil, nil),
+	"bridges_max_num_local_bridges":                     prometheus.NewDesc(namespace+"_"+"bridges_max_num_local_bridges", "Max number of Local Bridges", nil, nil),
+	"bridges_num_remote_bridges":                        prometheus.NewDesc(namespace+"_"+"bridges_num_remote_bridges", "Number of Remote Bridges", nil, nil),
+	"bridges_max_num_remote_bridges":                    prometheus.NewDesc(namespace+"_"+"bridges_max_num_remote_bridges", "Max number of Remote Bridges", nil, nil),
+	"bridges_num_total_remote_bridge_subscriptions":     prometheus.NewDesc(namespace+"_"+"bridges_num_total_remote_bridge_subscriptions", "Total number of Remote Bridge Subscription", nil, nil),
+	"bridges_max_num_total_remote_bridge_subscriptions": prometheus.NewDesc(namespace+"_"+"bridges_max_num_total_remote_bridge_subscriptions", "Max total number of Remote Bridge Subscription", nil, nil),
+
+	"bridge_admin_state":                  prometheus.NewDesc(namespace+"_"+"bridge_admin_state", "Bridge Administrative State (0-Enabled 1-Disabled)", variableLabelsBridge, nil),
+	"bridge_connection_establisher":       prometheus.NewDesc(namespace+"_"+"bridge_connection_establisher", "Connection Establisher", variableLabelsBridge, nil),
+	"bridge_inbound_operational_state":    prometheus.NewDesc(namespace+"_"+"bridge_inbound_operational_state", "Inbound Ops State", variableLabelsBridge, nil),
+	"bridge_outbound_operational_state":   prometheus.NewDesc(namespace+"_"+"bridge_outbound_operational_state", "Outbound Ops State", variableLabelsBridge, nil),
+	"bridge_queue_operational_state":      prometheus.NewDesc(namespace+"_"+"bridge_queue_operational_state", "Queue Ops State", variableLabelsBridge, nil),
+	"bridge_redundancy":                   prometheus.NewDesc(namespace+"_"+"bridge_redundancy", "Redundancy", variableLabelsBridge, nil),
+	"bridge_connection_uptime_in_seconds": prometheus.NewDesc(namespace+"_"+"bridge_connection_uptime_in_seconds", "Connection Uptime (s)", variableLabelsBridge, nil),
+
+	"bridge_client_num_subscriptions":        prometheus.NewDesc(namespace+"_"+"bridge_client_num_subscriptions", "Bridge Client Subscription", variableLabelsBridge, nil),
+	"bridge_client_slow_subscriber":          prometheus.NewDesc(namespace+"_"+"bridge_client_slow_subscriber", "Bridge Slow Subscriber", variableLabelsBridge, nil),
+	"bridge_total_client_messages_received":  prometheus.NewDesc(namespace+"_"+"bridge_total_client_messages_received", "Bridge Total Client Msg Received", variableLabelsBridge, nil),
+	"bridge_total_client_messages_sent":      prometheus.NewDesc(namespace+"_"+"bridge_total_client_messages_sent", "Bridge Client Messages sent", variableLabelsBridge, nil),
+	"bridge_denied_duplicate_clients":        prometheus.NewDesc(namespace+"_"+"bridge_denied_duplicate_clients", "Bridge Denied Duplicate Clients", variableLabelsBridge, nil),
+	"bridge_not_enough_space_msgs_sent":      prometheus.NewDesc(namespace+"_"+"bridge_not_enough_space_msgs_sent", "Bridge Not Enough Space Msgs sent", variableLabelsBridge, nil),
+	"bridge_max_exceeded_msgs_sent":          prometheus.NewDesc(namespace+"_"+"bridge_max_exceeded_msgs_sent", "Bridge Max Exceeded Msgs sent", variableLabelsBridge, nil),
+	"bridge_not_found_msgs_sent":             prometheus.NewDesc(namespace+"_"+"bridge_not_found_msgs_sent", "Bridge Not Found Msgs sent", variableLabelsBridge, nil),
+	"bridge_current_ingress_rate_per_second": prometheus.NewDesc(namespace+"_"+"bridge_current_ingress_rate_per_second", "Bridge current ingress rate (s)", variableLabelsBridge, nil),
+	"bridge_current_egress_rate_per_second":  prometheus.NewDesc(namespace+"_"+"bridge_current_egress_rate_per_second", "Bridge current egress rate (s)", variableLabelsBridge, nil),
+	"bridge_add_by_subscription_manager":     prometheus.NewDesc(namespace+"_"+"bridge_add_by_subscription_manager", "Add by subscription manager", variableLabelsBridge, nil),
+	"bridge_remove_by_subscription_manager":  prometheus.NewDesc(namespace+"_"+"bridge_remove_by_subscription_manager", "Remove by subscription manager", variableLabelsBridge, nil),
 }
 
 var metricsDet = metrics{
@@ -163,6 +204,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		}
 	} else { // Basic
 		if up > 0 && e.config.redundancy {
+			//if up > 0 {
 			up = e.getRedundancySemp1(ch)
 		}
 		if up > 0 {
@@ -173,6 +215,15 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		}
 		if up > 0 {
 			up = e.getVpnSemp1(ch)
+		}
+		if up > 0 {
+			up = e.getVpnReplicationSemp1(ch)
+		}
+		if up > 0 {
+			up = e.getBridgeSemp1(ch)
+		}
+		if up > 0 {
+			up = e.getBridgeStatsSemp1(ch)
 		}
 	}
 
@@ -420,6 +471,175 @@ func (e *Exporter) getHealthSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	return 1
 }
 
+// Get status of bridges for all vpns
+func (e *Exporter) getBridgeSemp1(ch chan<- prometheus.Metric) (ok float64) {
+
+	type Data struct {
+		RPC struct {
+			Show struct {
+				Bridge struct {
+					Bridges struct {
+						NumTotalBridgesValue                 float64 `xml:"num-total-bridges"`
+						MaxNumTotalBridgesValue              float64 `xml:"max-num-total-bridges"`
+						NumLocalBridgesValue                 float64 `xml:"num-local-bridges"`
+						MaxNumLocalBridgesValue              float64 `xml:"max-num-local-bridges"`
+						NumRemoteBridgesValue                float64 `xml:"num-remote-bridges"`
+						MaxNumRemoteBridgesValue             float64 `xml:"max-num-remote-bridges"`
+						NumTotalRemoteBridgeSubscriptions    float64 `xml:"num-total-remote-bridge-subscriptions"`
+						MaxNumTotalRemoteBridgeSubscriptions float64 `xml:"max-num-total-remote-bridge-subscriptions"`
+						Bridge                               []struct {
+							BridgeName                string  `xml:"bridge-name"`
+							LocalVpnName              string  `xml:"local-vpn-name"`
+							ConnectedRemoteVpnName    string  `xml:"connected-remote-vpn-name"`
+							ConnectedRemoteRouterName string  `xml:"connected-remote-router-name"`
+							AdminState                string  `xml:"admin-state"`
+							ConnectionEstablisher     string  `xml:"connection-establisher"`
+							InboundOperationalState   string  `xml:"inbound-operational-state"`
+							OutboundOperationalState  string  `xml:"outbound-operational-state"`
+							QueueOperationalState     string  `xml:"queue-operational-state"`
+							Redundancy                string  `xml:"redundancy"`
+							ConnectionUptimeInSeconds float64 `xml:"connection-uptime-in-seconds"`
+						} `xml:"bridge"`
+					} `xml:"bridges"`
+				} `xml:"bridge"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><bridge><bridge-name-pattern>*</bridge-name-pattern></bridge></show></rpc>"
+	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't scrape BridgeSemp1", "err", err)
+		return 0
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't decode Xml BridgeSemp1", "err", err)
+		return 0
+	}
+	if target.ExecuteResult.Result != "ok" {
+		level.Error(e.logger).Log("command", command)
+		return 0
+	}
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_total_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumTotalBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_total_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumTotalBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_local_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumLocalBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_local_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumLocalBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_remote_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumRemoteBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_remote_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumRemoteBridgesValue)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_num_total_remote_bridge_subscriptions"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumTotalRemoteBridgeSubscriptions)
+	ch <- prometheus.MustNewConstMetric(metricsStd["bridges_max_num_total_remote_bridge_subscriptions"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.MaxNumTotalRemoteBridgeSubscriptions)
+	opStates := []string{"NotApplicable", "Shutdown", "NotReady-Connecting", "NotReady-Handshaking", "NotReady-WaitNext", "NotReady-WaitReuse", "NotReady-WaitCleanup", "Ready-Subscribing", "Ready-InSync", "NotReady", "Ready"}
+	for _, bridge := range target.RPC.Show.Bridge.Bridges.Bridge {
+		bridgeName := bridge.BridgeName
+		vpnName := bridge.LocalVpnName
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_admin_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.AdminState, []string{"Enabled", "Disabled"}), bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_connection_establisher"], prometheus.GaugeValue, encodeMetricMulti(bridge.ConnectionEstablisher, []string{"NotApplicable", "Local", "Remote"}), bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_inbound_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.InboundOperationalState, opStates), bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_outbound_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.OutboundOperationalState, opStates), bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_queue_operational_state"], prometheus.GaugeValue, encodeMetricMulti(bridge.QueueOperationalState, opStates), bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_redundancy"], prometheus.GaugeValue, encodeMetricMulti(bridge.Redundancy, []string{"NotApplicable", "auto", "primary", "backup"}), bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_connection_uptime_in_seconds"], prometheus.GaugeValue, bridge.ConnectionUptimeInSeconds, bridgeName, vpnName)
+	}
+	return 1
+}
+
+// Get status of bridges for all vpns
+func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64) {
+
+	type Data struct {
+		RPC struct {
+			Show struct {
+				Bridge struct {
+					Bridges struct {
+						Bridge []struct {
+							BridgeName                string `xml:"bridge-name"`
+							LocalVpnName              string `xml:"local-vpn-name"`
+							ConnectedRemoteVpnName    string `xml:"connected-remote-vpn-name"`
+							ConnectedRemoteRouterName string `xml:"connected-remote-router-name"`
+							ConnectedViaAddr          string `xml:"connected-via-addr"`
+							ConnectedViaInterface     string `xml:"connected-via-interface"`
+							Redundancy                string `xml:"redundancy"`
+							AdminState                string `xml:"admin-state"`
+							ConnectionEstablisher     string `xml:"connection-establisher"`
+							Client                    struct {
+								ClientAddress    string  `xml:"client-address"`
+								Name             string  `xml:"name"`
+								NumSubscriptions float64 `xml:"num-subscriptions"`
+								ClientId         float64 `xml:"client-id"`
+								MessageVpn       float64 `xml:"message-vpn"`
+								SlowSubscriber   bool    `xml:"slow-subscriber"`
+								ClientUsername   string  `xml:"client-username"`
+								Stats            struct {
+									TotalClientMessagesReceived float64 `xml:"total-client-messages-received"`
+									TotalClientMessagesSent     float64 `xml:"total-client-messages-sent"`
+									DeniedDuplicateClients      float64 `xml:"denied-duplicate-clients"`
+									NotEnoughSpaceMsgsSent      float64 `xml:"not-enough-space-msgs-sent"`
+									MaxExceededMsgsSent         float64 `xml:"max-exceeded-msgs-sent"`
+									SubscribeClientNotFound     float64 `xml:"subscribe-client-not-found"`
+									NotFoundMsgsSent            float64 `xml:"not-found-msgs-sent"`
+									CurrentIngressRatePerSecond float64 `xml:"current-ingress-rate-per-second"`
+									CurrentEgressRatePerSecond  float64 `xml:"current-egress-rate-per-second"`
+									ManagedSubscriptions        struct {
+										AddBySubscriptionManager    float64 `xml:"add-by-subscription-manager"`
+										RemoveBySubscriptionManager float64 `xml:"remove-by-subscription-manager"`
+									}
+								}
+							}
+						} `xml:"bridge"`
+					} `xml:"bridges"`
+				} `xml:"bridge"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><bridge><bridge-name-pattern>*</bridge-name-pattern><stats/></bridge></show></rpc>"
+	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't scrape BridgeSemp1", "err", err)
+		return 0
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't decode Xml BridgeSemp1", "err", err)
+		return 0
+	}
+	if target.ExecuteResult.Result != "ok" {
+		level.Error(e.logger).Log("command", command)
+		return 0
+	}
+	for _, bridge := range target.RPC.Show.Bridge.Bridges.Bridge {
+		bridgeName := bridge.BridgeName
+		vpnName := bridge.LocalVpnName
+
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_num_subscriptions"], prometheus.GaugeValue, bridge.Client.NumSubscriptions, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_client_slow_subscriber"], prometheus.GaugeValue, encodeMetricBool(bridge.Client.SlowSubscriber), bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_received"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesReceived, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_client_messages_sent"], prometheus.GaugeValue, bridge.Client.Stats.TotalClientMessagesSent, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_denied_duplicate_clients"], prometheus.GaugeValue, bridge.Client.Stats.DeniedDuplicateClients, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_enough_space_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotEnoughSpaceMsgsSent, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_max_exceeded_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.MaxExceededMsgsSent, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_not_found_msgs_sent"], prometheus.GaugeValue, bridge.Client.Stats.NotFoundMsgsSent, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_ingress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentIngressRatePerSecond, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_current_egress_rate_per_second"], prometheus.GaugeValue, bridge.Client.Stats.CurrentEgressRatePerSecond, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_add_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.AddBySubscriptionManager, bridgeName, vpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_remove_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.RemoveBySubscriptionManager, bridgeName, vpnName)
+	}
+	return 1
+}
+
 // Get status and number of connected clients of all vpn's, and some data stats and rates
 func (e *Exporter) getVpnSemp1(ch chan<- prometheus.Metric) (ok float64) {
 
@@ -489,6 +709,117 @@ func (e *Exporter) getVpnSemp1(ch chan<- prometheus.Metric) (ok float64) {
 		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_tx_bytes_total"], prometheus.CounterValue, vpn.Stats.DataTxByteCount, vpn.Name)
 		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_rx_discarded_msgs_total"], prometheus.CounterValue, vpn.Stats.IngressDiscards.DiscardedRxMsgCount, vpn.Name)
 		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_tx_discarded_msgs_total"], prometheus.CounterValue, vpn.Stats.EgressDiscards.DiscardedTxMsgCount, vpn.Name)
+	}
+
+	return 1
+}
+
+// Config Sync Status
+func (e *Exporter) getConfigSyncSemp1(ch chan<- prometheus.Metric) (ok float64) {
+
+	type Data struct {
+		RPC struct {
+			Show struct {
+				ConfigSync struct {
+					Database struct {
+						Local struct {
+							Tables struct {
+								Table []struct {
+									Type               string  `xml:"type"`
+									TimeInStateSeconds float64 `xml:"time-in-state-seconds"`
+									Name               string  `xml:"name"`
+									Ownership          string  `xml:"ownership"`
+									SyncState          string  `xml:"sync-state"`
+									TimeInState        string  `xml:"time-in-state"`
+								} `xml:"table"`
+							} `xml:"tables"`
+						} `xml:"local"`
+					} `xml:"database"`
+				} `xml:"config-sync"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><config-sync><database/></config-sync></show></rpc>"
+	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err)
+		return 0
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't decode Xml ConfigSyncSemp1", "err", err)
+		return 0
+	}
+	if target.ExecuteResult.Result != "ok" {
+		level.Error(e.logger).Log("command", command)
+		return 0
+	}
+
+	for _, table := range target.RPC.Show.ConfigSync.Database.Local.Tables.Table {
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_type"], prometheus.GaugeValue, encodeMetricMulti(table.Type, []string{"Router", "Vpn"}), table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_timeinstateseconds"], prometheus.CounterValue, table.TimeInStateSeconds, table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_ownership"], prometheus.GaugeValue, encodeMetricMulti(table.Ownership, []string{"Master", "Slave"}), table.Name)
+		ch <- prometheus.MustNewConstMetric(metricsStd["configsync_table_syncstate"], prometheus.GaugeValue, encodeMetricMulti(table.SyncState, []string{"Down", "Up"}), table.Name)
+	}
+
+	return 1
+}
+
+// Replication Config and status
+func (e *Exporter) getVpnReplicationSemp1(ch chan<- prometheus.Metric) (ok float64) {
+
+	type Data struct {
+		RPC struct {
+			Show struct {
+				MessageVpn struct {
+					Replication struct {
+						MessageVpns struct {
+							MessageVpn []struct {
+								VpnName                    string `xml:"vpn-name"`
+								AdminState                 string `xml:"admin-state"`
+								ConfigState                string `xml:"config-state"`
+								TransactionReplicationMode string `xml:"transaction-replication-mode"`
+							} `xml:"message-vpn"`
+						} `xml:"message-vpns"`
+					} `xml:"replication"`
+				} `xml:"message-vpn"`
+			} `xml:"show"`
+		} `xml:"rpc"`
+		ExecuteResult struct {
+			Result string `xml:"code,attr"`
+		} `xml:"execute-result"`
+	}
+
+	command := "<rpc><show><message-vpn><vpn-name>*</vpn-name><replication/></message-vpn></show></rpc>"
+	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err)
+		return 0
+	}
+	defer body.Close()
+	decoder := xml.NewDecoder(body)
+	var target Data
+	err = decoder.Decode(&target)
+	if err != nil {
+		level.Error(e.logger).Log("msg", "Can't decode Xml VpnSemp1", "err", err)
+		return 0
+	}
+	if target.ExecuteResult.Result != "ok" {
+		level.Error(e.logger).Log("command", command)
+		return 0
+	}
+
+	for _, vpn := range target.RPC.Show.MessageVpn.Replication.MessageVpns.MessageVpn {
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_replication_admin_state"], prometheus.GaugeValue, encodeMetricMulti(vpn.AdminState, []string{"shutdown", "enabled"}), vpn.VpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_replication_config_state"], prometheus.GaugeValue, encodeMetricMulti(vpn.ConfigState, []string{"standby", "active"}), vpn.VpnName)
+		ch <- prometheus.MustNewConstMetric(metricsStd["vpn_replication_transaction_replication_mode"], prometheus.GaugeValue, encodeMetricMulti(vpn.TransactionReplicationMode, []string{"async", "sync"}), vpn.VpnName)
 	}
 
 	return 1

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -45,7 +45,7 @@ type metrics map[string]*prometheus.Desc
 
 var (
 	vmrVersion            = string("undefined")
-	solaceExporterVersion = float64(1001007)
+	solaceExporterVersion = float64(1001008)
 
 	variableLabelsVersion         = []string{"vmrVersion"}
 	variableExporterVersion       = []string{"vmrVersion"}
@@ -162,6 +162,11 @@ var metricsStd = metrics{
 }
 
 var metricsDet = metrics{
+	// version
+	"system_version_currentload":      prometheus.NewDesc(namespace+"_"+"system_version_currentload", "Solace Version as WWWXXXYYYZZZ ", variableLabelsVersion, nil),
+	"system_version_uptime_totalsecs": prometheus.NewDesc(namespace+"_"+"system_version_uptime_totalsecs", "Broker uptime in seconds ", variableLabelsVersion, nil),
+	"exporter_version_current":        prometheus.NewDesc(namespace+"_"+"exporter_version_current", "Exporter Version ", variableLabelsVersion, nil),
+
 	"client_rx_msgs_total":           prometheus.NewDesc(namespace+"_"+"client_rx_msgs_total", "Number of received messages.", variableLabelsVpnClient, nil),
 	"client_tx_msgs_total":           prometheus.NewDesc(namespace+"_"+"client_tx_msgs_total", "Number of transmitted messages.", variableLabelsVpnClient, nil),
 	"client_rx_bytes_total":          prometheus.NewDesc(namespace+"_"+"client_rx_bytes_total", "Number of received bytes.", variableLabelsVpnClient, nil),

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -60,15 +60,18 @@ var (
 )
 
 var metricsStd = metrics{
+	// version
 	"system_version_currentload":      prometheus.NewDesc(namespace+"_"+"system_version_currentload", "Solace Version as WWWXXXYYYZZZ ", variableLabelsVersion, nil),
 	"system_version_uptime_totalsecs": prometheus.NewDesc(namespace+"_"+"system_version_uptime_totalsecs", "Broker uptime in seconds ", variableLabelsVersion, nil),
 	"exporter_version_current":        prometheus.NewDesc(namespace+"_"+"exporter_version_current", "Exporter Version ", variableLabelsVersion, nil),
 
+	// redundancy
 	"system_redundancy_up":           prometheus.NewDesc(namespace+"_"+"system_redundancy_up", "Is redundancy up? (0=down, 1=up).", variableLabelsRedundancy, nil),
 	"system_redundancy_config":       prometheus.NewDesc(namespace+"_"+"system_redundancy_config", "Redundancy configuration (0=disabled, 1=enabled, 2=shutdown).", variableLabelsRedundancy, nil),
 	"system_redundancy_role":         prometheus.NewDesc(namespace+"_"+"system_redundancy_role", "Redundancy role (0=backup, 1=primary, 2=monitor).", variableLabelsRedundancy, nil),
 	"system_redundancy_local_active": prometheus.NewDesc(namespace+"_"+"system_redundancy_local_active", "Is local node the active messaging node? (0=not active, 1=active).", variableLabelsRedundancy, nil),
 
+	// system
 	"system_spool_quota_bytes":             prometheus.NewDesc(namespace+"_"+"system_spool_quota_bytes", "Spool configured max disk usage.", variableLabelsVersion, nil),
 	"system_spool_quota_msgs":              prometheus.NewDesc(namespace+"_"+"system_spool_quota_msgs", "Spool configured max number of messages.", variableLabelsVersion, nil),
 	"system_spool_usage_bytes":             prometheus.NewDesc(namespace+"_"+"system_spool_usage_bytes", "Spool total persisted usage.", variableLabelsVersion, nil),
@@ -86,24 +89,26 @@ var metricsStd = metrics{
 	"system_mate_link_latency_avg_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_avg_seconds", "Average mate link latency.", variableLabelsVersion, nil),
 	"system_mate_link_latency_cur_seconds": prometheus.NewDesc(namespace+"_"+"system_mate_link_latency_cur_seconds", "Current mate link latency.", variableLabelsVersion, nil),
 
+	// config sync
 	"configsync_table_type":               prometheus.NewDesc(namespace+"_"+"configsync_table_type", "Config Sync Resource Type", variableLabelsConfigSyncTable, nil),
 	"configsync_table_timeinstateseconds": prometheus.NewDesc(namespace+"_"+"configsync_table_timeinstateseconds", "Config Sync Time in State", variableLabelsConfigSyncTable, nil),
 	"configsync_table_ownership":          prometheus.NewDesc(namespace+"_"+"configsync_table_ownership", "Config Sync Ownership", variableLabelsConfigSyncTable, nil),
 	"configsync_table_syncstate":          prometheus.NewDesc(namespace+"_"+"configsync_table_syncstate", "Config Sync State", variableLabelsConfigSyncTable, nil),
 
-	"vpn_local_status":            prometheus.NewDesc(namespace+"_"+"vpn_local_status", "Local status (0=Down, 1=Up).", variableLabelsVpn, nil),
-	"vpn_connections":             prometheus.NewDesc(namespace+"_"+"vpn_connections", "Number of connections.", variableLabelsVpn, nil),
-	"vpn_rx_msgs_total":           prometheus.NewDesc(namespace+"_"+"vpn_rx_msgs_total", "Number of received messages.", variableLabelsVpn, nil),
-	"vpn_tx_msgs_total":           prometheus.NewDesc(namespace+"_"+"vpn_tx_msgs_total", "Number of transmitted messages.", variableLabelsVpn, nil),
-	"vpn_rx_bytes_total":          prometheus.NewDesc(namespace+"_"+"vpn_rx_bytes_total", "Number of received bytes.", variableLabelsVpn, nil),
-	"vpn_tx_bytes_total":          prometheus.NewDesc(namespace+"_"+"vpn_tx_bytes_total", "Number of transmitted bytes.", variableLabelsVpn, nil),
-	"vpn_rx_discarded_msgs_total": prometheus.NewDesc(namespace+"_"+"vpn_rx_discarded_msgs_total", "Number of discarded received messages.", variableLabelsVpn, nil),
-	"vpn_tx_discarded_msgs_total": prometheus.NewDesc(namespace+"_"+"vpn_tx_discarded_msgs_total", "Number of discarded transmitted messages.", variableLabelsVpn, nil),
-
+	// vpn
+	"vpn_local_status":                             prometheus.NewDesc(namespace+"_"+"vpn_local_status", "Local status (0=Down, 1=Up).", variableLabelsVpn, nil),
+	"vpn_connections":                              prometheus.NewDesc(namespace+"_"+"vpn_connections", "Number of connections.", variableLabelsVpn, nil),
+	"vpn_rx_msgs_total":                            prometheus.NewDesc(namespace+"_"+"vpn_rx_msgs_total", "Number of received messages.", variableLabelsVpn, nil),
+	"vpn_tx_msgs_total":                            prometheus.NewDesc(namespace+"_"+"vpn_tx_msgs_total", "Number of transmitted messages.", variableLabelsVpn, nil),
+	"vpn_rx_bytes_total":                           prometheus.NewDesc(namespace+"_"+"vpn_rx_bytes_total", "Number of received bytes.", variableLabelsVpn, nil),
+	"vpn_tx_bytes_total":                           prometheus.NewDesc(namespace+"_"+"vpn_tx_bytes_total", "Number of transmitted bytes.", variableLabelsVpn, nil),
+	"vpn_rx_discarded_msgs_total":                  prometheus.NewDesc(namespace+"_"+"vpn_rx_discarded_msgs_total", "Number of discarded received messages.", variableLabelsVpn, nil),
+	"vpn_tx_discarded_msgs_total":                  prometheus.NewDesc(namespace+"_"+"vpn_tx_discarded_msgs_total", "Number of discarded transmitted messages.", variableLabelsVpn, nil),
 	"vpn_replication_admin_state":                  prometheus.NewDesc(namespace+"_"+"vpn_replication_admin_state", "Replication Admin Status", variableLabelsVpn, nil),
 	"vpn_replication_config_state":                 prometheus.NewDesc(namespace+"_"+"vpn_replication_config_state", "Replication Config Status", variableLabelsVpn, nil),
 	"vpn_replication_transaction_replication_mode": prometheus.NewDesc(namespace+"_"+"vpn_replication_transaction_replication_mode", "Replication Tx Replication Mode", variableLabelsVpn, nil),
 
+	//bridges
 	"bridges_num_total_bridges":                         prometheus.NewDesc(namespace+"_"+"bridges_num_total_bridges", "Number of Bridges", variableLabelsVersion, nil),
 	"bridges_max_num_total_bridges":                     prometheus.NewDesc(namespace+"_"+"bridges_max_num_total_bridges", "Max number of Bridges", variableLabelsVersion, nil),
 	"bridges_num_local_bridges":                         prometheus.NewDesc(namespace+"_"+"bridges_num_local_bridges", "Number of Local Bridges", variableLabelsVersion, nil),
@@ -113,18 +118,17 @@ var metricsStd = metrics{
 	"bridges_num_total_remote_bridge_subscriptions":     prometheus.NewDesc(namespace+"_"+"bridges_num_total_remote_bridge_subscriptions", "Total number of Remote Bridge Subscription", variableLabelsVersion, nil),
 	"bridges_max_num_total_remote_bridge_subscriptions": prometheus.NewDesc(namespace+"_"+"bridges_max_num_total_remote_bridge_subscriptions", "Max total number of Remote Bridge Subscription", variableLabelsVersion, nil),
 
-	"bridge_admin_state":                        prometheus.NewDesc(namespace+"_"+"bridge_admin_state", "Bridge Administrative State (0-Enabled 1-Disabled)", variableLabelsBridge, nil),
-	"bridge_connection_establisher":             prometheus.NewDesc(namespace+"_"+"bridge_connection_establisher", "Connection Establisher", variableLabelsBridge, nil),
-	"bridge_inbound_operational_state":          prometheus.NewDesc(namespace+"_"+"bridge_inbound_operational_state", "Inbound Ops State", variableLabelsBridge, nil),
-	"bridge_inbound_operational_failure_reason": prometheus.NewDesc(namespace+"_"+"bridge_inbound_operational_failure_reason", "Inbound Ops Failure Reason", variableLabelsBridge, nil),
-	"bridge_outbound_operational_state":         prometheus.NewDesc(namespace+"_"+"bridge_outbound_operational_state", "Outbound Ops State", variableLabelsBridge, nil),
-	"bridge_queue_operational_state":            prometheus.NewDesc(namespace+"_"+"bridge_queue_operational_state", "Queue Ops State", variableLabelsBridge, nil),
-	"bridge_redundancy":                         prometheus.NewDesc(namespace+"_"+"bridge_redundancy", "Redundancy", variableLabelsBridge, nil),
-	"bridge_connection_uptime_in_seconds":       prometheus.NewDesc(namespace+"_"+"bridge_connection_uptime_in_seconds", "Connection Uptime (s)", variableLabelsBridge, nil),
-
-	"bridge_client_num_subscriptions": prometheus.NewDesc(namespace+"_"+"bridge_client_num_subscriptions", "Bridge Client Subscription", variableLabelsBridge, nil),
-	"bridge_client_slow_subscriber":   prometheus.NewDesc(namespace+"_"+"bridge_client_slow_subscriber", "Bridge Slow Subscriber", variableLabelsBridge, nil),
-
+	// bridge
+	"bridge_admin_state":                            prometheus.NewDesc(namespace+"_"+"bridge_admin_state", "Bridge Administrative State (0-Enabled 1-Disabled)", variableLabelsBridge, nil),
+	"bridge_connection_establisher":                 prometheus.NewDesc(namespace+"_"+"bridge_connection_establisher", "Connection Establisher", variableLabelsBridge, nil),
+	"bridge_inbound_operational_state":              prometheus.NewDesc(namespace+"_"+"bridge_inbound_operational_state", "Inbound Ops State", variableLabelsBridge, nil),
+	"bridge_inbound_operational_failure_reason":     prometheus.NewDesc(namespace+"_"+"bridge_inbound_operational_failure_reason", "Inbound Ops Failure Reason", variableLabelsBridge, nil),
+	"bridge_outbound_operational_state":             prometheus.NewDesc(namespace+"_"+"bridge_outbound_operational_state", "Outbound Ops State", variableLabelsBridge, nil),
+	"bridge_queue_operational_state":                prometheus.NewDesc(namespace+"_"+"bridge_queue_operational_state", "Queue Ops State", variableLabelsBridge, nil),
+	"bridge_redundancy":                             prometheus.NewDesc(namespace+"_"+"bridge_redundancy", "Redundancy", variableLabelsBridge, nil),
+	"bridge_connection_uptime_in_seconds":           prometheus.NewDesc(namespace+"_"+"bridge_connection_uptime_in_seconds", "Connection Uptime (s)", variableLabelsBridge, nil),
+	"bridge_client_num_subscriptions":               prometheus.NewDesc(namespace+"_"+"bridge_client_num_subscriptions", "Bridge Client Subscription", variableLabelsBridge, nil),
+	"bridge_client_slow_subscriber":                 prometheus.NewDesc(namespace+"_"+"bridge_client_slow_subscriber", "Bridge Slow Subscriber", variableLabelsBridge, nil),
 	"bridge_total_client_messages_received":         prometheus.NewDesc(namespace+"_"+"bridge_total_client_messages_received", "Bridge Total Client Messages Received", variableLabelsBridge, nil),
 	"bridge_total_client_messages_sent":             prometheus.NewDesc(namespace+"_"+"bridge_total_client_messages_sent", "Bridge Total Client Messages sent", variableLabelsBridge, nil),
 	"bridge_client_data_messages_received":          prometheus.NewDesc(namespace+"_"+"bridge_client_data_messages_received", "Bridge Client Data Msgs Received", variableLabelsBridge, nil),
@@ -135,29 +139,26 @@ var metricsStd = metrics{
 	"bridge_client_nonpersistent_messages_sent":     prometheus.NewDesc(namespace+"_"+"bridge_client_nonpersistent_messages_sent", "Bridge Client Non-Persistent Msgs Sent", variableLabelsBridge, nil),
 	"bridge_client_direct_messages_received":        prometheus.NewDesc(namespace+"_"+"bridge_client_direct_messages_received", "Bridge Client Direct Msgs Received", variableLabelsBridge, nil),
 	"bridge_client_direct_messages_sent":            prometheus.NewDesc(namespace+"_"+"bridge_client_direct_messages_sent", "Bridge Client Direct Msgs Sent", variableLabelsBridge, nil),
-
-	"bridge_total_client_bytes_received":         prometheus.NewDesc(namespace+"_"+"bridge_total_client_bytes_received", "Bridge Total Client Bytes Received", variableLabelsBridge, nil),
-	"bridge_total_client_bytess_sent":            prometheus.NewDesc(namespace+"_"+"bridge_total_client_bytess_sent", "Bridge Total Client Bytes sent", variableLabelsBridge, nil),
-	"bridge_client_data_bytes_received":          prometheus.NewDesc(namespace+"_"+"bridge_client_data_bytes_received", "Bridge Client Data Bytes Received", variableLabelsBridge, nil),
-	"bridge_client_data_bytes_sent":              prometheus.NewDesc(namespace+"_"+"bridge_client_data_bytes_sent", "Bridge Client Data Bytes Sent", variableLabelsBridge, nil),
-	"bridge_client_persistent_bytes_received":    prometheus.NewDesc(namespace+"_"+"bridge_client_persistent_bytes_received", "Bridge Client Persistent Bytes Received", variableLabelsBridge, nil),
-	"bridge_client_persistent_bytes_sent":        prometheus.NewDesc(namespace+"_"+"bridge_client_persistent_bytes_sent", "Bridge Client Persistent Bytes Sent", variableLabelsBridge, nil),
-	"bridge_client_nonpersistent_bytes_received": prometheus.NewDesc(namespace+"_"+"bridge_client_nonpersistent_bytes_received", "Bridge Client Non-Persistent Bytes Received", variableLabelsBridge, nil),
-	"bridge_client_nonpersistent_bytes_sent":     prometheus.NewDesc(namespace+"_"+"bridge_client_nonpersistent_bytes_sent", "Bridge Client Non-Persistent Bytes Sent", variableLabelsBridge, nil),
-	"bridge_client_direct_bytes_received":        prometheus.NewDesc(namespace+"_"+"bridge_client_direct_bytes_received", "Bridge Client Direct Bytes Received", variableLabelsBridge, nil),
-	"bridge_client_direct_bytes_sent":            prometheus.NewDesc(namespace+"_"+"bridge_client_direct_bytes_sent", "Bridge Client Direct Bytes Sent", variableLabelsBridge, nil),
-
-	"bridge_client_large_messages_received":  prometheus.NewDesc(namespace+"_"+"bridge_client_large_messages_received", "Bridge Client Large Messages received", variableLabelsBridge, nil),
-	"bridge_denied_duplicate_clients":        prometheus.NewDesc(namespace+"_"+"bridge_denied_duplicate_clients", "Bridge Deneid Duplicate Clients", variableLabelsBridge, nil),
-	"bridge_not_enough_space_msgs_sent":      prometheus.NewDesc(namespace+"_"+"bridge_not_enough_space_msgs_sent", "Bridge Not Enough Space Messages Sent", variableLabelsBridge, nil),
-	"bridge_max_exceeded_msgs_sent":          prometheus.NewDesc(namespace+"_"+"bridge_max_exceeded_msgs_sent", "Bridge Max Exceeded Messages Sent", variableLabelsBridge, nil),
-	"bridge_subscribe_client_not_found":      prometheus.NewDesc(namespace+"_"+"bridge_subscribe_client_not_found", "Bridge Subscriber Client Not Found", variableLabelsBridge, nil),
-	"bridge_not_found_msgs_sent":             prometheus.NewDesc(namespace+"_"+"bridge_not_found_msgs_sent", "Bridge Not Found Messages Sent", variableLabelsBridge, nil),
-	"bridge_current_ingress_rate_per_second": prometheus.NewDesc(namespace+"_"+"bridge_current_ingress_rate_per_second", "Current Ingress Rate / s", variableLabelsBridge, nil),
-	"bridge_current_egress_rate_per_second":  prometheus.NewDesc(namespace+"_"+"bridge_current_egress_rate_per_second", "Current Egress Rate / s", variableLabelsBridge, nil),
-
-	"bridge_total_ingress_discards": prometheus.NewDesc(namespace+"_"+"bridge_total_ingress_discards", "Total Ingress Discards", variableLabelsBridge, nil),
-	"bridge_total_egress_discards":  prometheus.NewDesc(namespace+"_"+"bridge_total_egress_discards", "Total Egress Discards", variableLabelsBridge, nil),
+	"bridge_total_client_bytes_received":            prometheus.NewDesc(namespace+"_"+"bridge_total_client_bytes_received", "Bridge Total Client Bytes Received", variableLabelsBridge, nil),
+	"bridge_total_client_bytess_sent":               prometheus.NewDesc(namespace+"_"+"bridge_total_client_bytess_sent", "Bridge Total Client Bytes sent", variableLabelsBridge, nil),
+	"bridge_client_data_bytes_received":             prometheus.NewDesc(namespace+"_"+"bridge_client_data_bytes_received", "Bridge Client Data Bytes Received", variableLabelsBridge, nil),
+	"bridge_client_data_bytes_sent":                 prometheus.NewDesc(namespace+"_"+"bridge_client_data_bytes_sent", "Bridge Client Data Bytes Sent", variableLabelsBridge, nil),
+	"bridge_client_persistent_bytes_received":       prometheus.NewDesc(namespace+"_"+"bridge_client_persistent_bytes_received", "Bridge Client Persistent Bytes Received", variableLabelsBridge, nil),
+	"bridge_client_persistent_bytes_sent":           prometheus.NewDesc(namespace+"_"+"bridge_client_persistent_bytes_sent", "Bridge Client Persistent Bytes Sent", variableLabelsBridge, nil),
+	"bridge_client_nonpersistent_bytes_received":    prometheus.NewDesc(namespace+"_"+"bridge_client_nonpersistent_bytes_received", "Bridge Client Non-Persistent Bytes Received", variableLabelsBridge, nil),
+	"bridge_client_nonpersistent_bytes_sent":        prometheus.NewDesc(namespace+"_"+"bridge_client_nonpersistent_bytes_sent", "Bridge Client Non-Persistent Bytes Sent", variableLabelsBridge, nil),
+	"bridge_client_direct_bytes_received":           prometheus.NewDesc(namespace+"_"+"bridge_client_direct_bytes_received", "Bridge Client Direct Bytes Received", variableLabelsBridge, nil),
+	"bridge_client_direct_bytes_sent":               prometheus.NewDesc(namespace+"_"+"bridge_client_direct_bytes_sent", "Bridge Client Direct Bytes Sent", variableLabelsBridge, nil),
+	"bridge_client_large_messages_received":         prometheus.NewDesc(namespace+"_"+"bridge_client_large_messages_received", "Bridge Client Large Messages received", variableLabelsBridge, nil),
+	"bridge_denied_duplicate_clients":               prometheus.NewDesc(namespace+"_"+"bridge_denied_duplicate_clients", "Bridge Deneid Duplicate Clients", variableLabelsBridge, nil),
+	"bridge_not_enough_space_msgs_sent":             prometheus.NewDesc(namespace+"_"+"bridge_not_enough_space_msgs_sent", "Bridge Not Enough Space Messages Sent", variableLabelsBridge, nil),
+	"bridge_max_exceeded_msgs_sent":                 prometheus.NewDesc(namespace+"_"+"bridge_max_exceeded_msgs_sent", "Bridge Max Exceeded Messages Sent", variableLabelsBridge, nil),
+	"bridge_subscribe_client_not_found":             prometheus.NewDesc(namespace+"_"+"bridge_subscribe_client_not_found", "Bridge Subscriber Client Not Found", variableLabelsBridge, nil),
+	"bridge_not_found_msgs_sent":                    prometheus.NewDesc(namespace+"_"+"bridge_not_found_msgs_sent", "Bridge Not Found Messages Sent", variableLabelsBridge, nil),
+	"bridge_current_ingress_rate_per_second":        prometheus.NewDesc(namespace+"_"+"bridge_current_ingress_rate_per_second", "Current Ingress Rate / s", variableLabelsBridge, nil),
+	"bridge_current_egress_rate_per_second":         prometheus.NewDesc(namespace+"_"+"bridge_current_egress_rate_per_second", "Current Egress Rate / s", variableLabelsBridge, nil),
+	"bridge_total_ingress_discards":                 prometheus.NewDesc(namespace+"_"+"bridge_total_ingress_discards", "Total Ingress Discards", variableLabelsBridge, nil),
+	"bridge_total_egress_discards":                  prometheus.NewDesc(namespace+"_"+"bridge_total_egress_discards", "Total Egress Discards", variableLabelsBridge, nil),
 }
 
 var metricsDet = metrics{
@@ -661,7 +662,7 @@ func (e *Exporter) getBridgeSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	return 1
 }
 
-// Get status of bridges for all vpns
+// Get statistics of bridges for all vpns
 func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64) {
 
 	type Data struct {
@@ -815,9 +816,6 @@ func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 
 		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_ingress_discards"], prometheus.GaugeValue, bridge.Client.Stats.IngressDiscards.TotalIngressDiscards, vmrVersion, bridgeName, vpnName)
 		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_total_egress_discards"], prometheus.GaugeValue, bridge.Client.Stats.EgressDiscards.TotalEgressDiscards, vmrVersion, bridgeName, vpnName)
-		//
-		//		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_add_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.AddBySubscriptionManager, vmrVersion, bridgeName, vpnName)
-		//		ch <- prometheus.MustNewConstMetric(metricsStd["bridge_remove_by_subscription_manager"], prometheus.GaugeValue, bridge.Client.Stats.ManagedSubscriptions.RemoveBySubscriptionManager, vmrVersion, bridgeName, vpnName)
 	}
 	return 1
 }
@@ -896,7 +894,7 @@ func (e *Exporter) getVpnSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	return 1
 }
 
-// Config Sync Status
+// Config Sync Status for Broker and Vpn
 func (e *Exporter) getConfigSyncSemp1(ch chan<- prometheus.Metric) (ok float64) {
 
 	type Data struct {

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -238,7 +238,7 @@ func (e *Exporter) getVersionSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Can't scrape getVersionSemp1", "err", err)
-		return 0
+		return -3
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
@@ -246,11 +246,11 @@ func (e *Exporter) getVersionSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	err = decoder.Decode(&target)
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Can't decode Xml getVersionSemp1", "err", err)
-		return 0
+		return -2
 	}
 	if target.ExecuteResult.Result != "ok" {
 		level.Error(e.logger).Log("command", command)
-		return 0
+		return -1
 	}
 
 	// remember this for the label


### PR DESCRIPTION
This fork extends the existing code schema to include additional metrics for Solace Bridges.
Also a version tag is introduced for Solace broker, along with a metric for both the broker version and the exporter version itself. To include the version tag to metrics, it must made sure the version query is run upfront any other metric query, as the version is kept as a package scoped variable.