### PR TITLE
url based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,22 @@ It is currently only tested against PubSub+ software brokers (VMRs), not applian
 
 The exporter is written in go, based on the Solace Legacy SEMP protocol.<br/>
 It implements the following endpoints:<br/>
-<pre><code>http://&lt;host&gt;:&lt;port&gt;/         Document page showing list of endpoints
-http://&lt;host&gt;:&lt;port&gt;/metrics             Golang and standard Prometheus metrics
-http://&lt;host&gt;:&lt;port&gt;/solace-std          Solace metrics for System and VPN levels
-http://&lt;host&gt;:&lt;port&gt;/solace-det          Solace metrics for Messaging Clients and Queues
-http://&lt;host&gt;:&lt;port&gt;/solace-broker-std   Solace Broker only Standard Metrics (System)
-http://&lt;host&gt;:&lt;port&gt;/solace-vpn-std      Solace Vpn only Standard Metrics (VPN), available to non-global access right admins
-http://&lt;host&gt;:&lt;port&gt;/solace-vpn-stats    Solace Vpn only Statistics Metrics (VPN), available to non-global access right admins
-http://&lt;host&gt;:&lt;port&gt;/solace-vpn-det      Solace Vpn only Detailed Metrics (VPN), available to non-global access right admins
-</code></pre>
+```
+http://<host>:<port>/         Document page showing list of endpoints
+http://<host>:<port>/metrics             Golang and standard Prometheus metrics
+http://<host>:<port>/solace-std          Solace metrics for System and VPN levels
+http://<host>:<port>/solace-det          Solace metrics for Messaging Clients and Queues
+http://<host>:<port>/solace-broker-std   Solace Broker only Standard Metrics (System)
+http://<host>:<port>/solace-vpn-std      Solace Vpn only Standard Metrics (VPN), available to non-global access right admins
+http://<host>:<port>/solace-vpn-stats    Solace Vpn only Statistics Metrics (VPN), available to non-global access right admins
+http://<host>:<port>/solace-vpn-det      Solace Vpn only Detailed Metrics (VPN), available to non-global access right admins
+```
 The [registered](https://github.com/prometheus/prometheus/wiki/Default-port-allocations) default port for Solace is 9628<br/>
 
 ## Usage
 
-<pre><code>solace_exporter -h
+```
+solace_exporter -h
 usage: solace_exporter [&lt;flags&gt;]
 
 Flags:
@@ -32,15 +34,19 @@ Flags:
       --log.level=info           Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt        Output format of log messages. One of: [logfmt, json]
       --config-file=CONFIG-FILE  Path and name of config file. See sample file solace_exporter.ini.</code></pre>
+```
 
 The configuration parameters can be placed into a config file or into a set of environment variables or can be given via URL. For Docker you should prefer the environment variable configuration method (see below).<br/> If the exporter is started with a config file argument then the config file entries have precedence over the environment variables. If a parameter is neither found in URL nor the config file nor in the environment the exporter exits with an error.<br/>
 
 ### Config File
 
-<pre><code>solace_exporter --config-file /path/to/config/file.ini</code></pre>
+```bash
+solace_exporter --config-file /path/to/config/file.ini
+```
 
 Sample config file:
-<pre><code>[solace]
+```ini
+[solace]
 # Address to listen on for web interface and telemetry.
 listenAddr=0.0.0.0:9628
 
@@ -61,17 +67,19 @@ sslVerify=false
 
 # Flag that enables scrape of redundancy metrics. Should be used for broker HA groups.
 redundancy=false
-</code></pre>
+```
 
 ### Environment Variables
 Sample environment variables:
-<pre><code>SOLACE_LISTEN_ADDR=0.0.0.0:9628
+```bash
+SOLACE_LISTEN_ADDR=0.0.0.0:9628
 SOLACE_SCRAPE_URI=http://localhost:8080
 SOLACE_USERNAME=admin
 SOLACE_PASSWORD=admin
 SOLACE_TIMEOUT=5s
 SOLACE_SSL_VERIFY=false
-SOLACE_REDUNDANCY=false</code></pre>
+SOLACE_REDUNDANCY=false
+```
 
 ### URL
 
@@ -89,7 +97,8 @@ Security: Only use this feature with HTTPS.
 
 #### Sample prometheus config
 
-<pre><code>- job_name: 'solace-std'
+```prometheus
+- job_name: 'solace-std'
   scrape_interval: 15s
   metrics_path: /solace-std
   static_configs:
@@ -104,14 +113,15 @@ Security: Only use this feature with HTTPS.
       target_label: instance
     - target_label: __address__
       replacement: solace-exporter:9628
-</code></pre>
+```
 
 ## Build
 
 ### Default Build
-<pre><code>cd &lt;some-directory&gt;/solace_exporter
+```bash
+cd &lt;some-directory&gt;/solace_exporter
 go build
-</code></pre>
+```
 
 ## Docker
 
@@ -124,20 +134,24 @@ This is used to automatically build and push the latest image to the Dockerhub r
 
 Environment variables are recommended to parameterize the exporter in Docker.<br/>
 Put the following parameters, adapted to your situation, into a file on the local host, e.g. env.txt:<br/>
-<pre><code>SOLACE_LISTEN_ADDR=0.0.0.0:9628
+```bash
+SOLACE_LISTEN_ADDR=0.0.0.0:9628
 SOLACE_SCRAPE_URI=http://localhost:8080
 SOLACE_USERNAME=admin
 SOLACE_PASSWORD=admin
 SOLACE_TIMEOUT=5s
 SOLACE_SSL_VERIFY=false
-SOLACE_REDUNDANCY=false</code></pre>
+SOLACE_REDUNDANCY=false
+```
 
 Then run
-<pre><code>docker run -d \
+```bash
+docker run -d \
  -p 9628:9628 \
  --env-file env.txt \
  --name solace-exporter \
- dabgmx/solace-exporter</code></pre>
+ dabgmx/solace-exporter
+```
 
 ## Bonus Material
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Flags:
       --log.format=logfmt        Output format of log messages. One of: [logfmt, json]
       --config-file=CONFIG-FILE  Path and name of config file. See sample file solace_exporter.ini.</code></pre>
 
-The configuration parameters can be placed into a config file or into a set of environment variables. For Docker you should prefer the environment variable configuration method (see below).<br/> If the exporter is started with a config file argument then the config file entries have precedence over the environment variables. If a parameter is neither found in the config file nor in the environment the exporter exits with an error.<br/>
+The configuration parameters can be placed into a config file or into a set of environment variables or can be given via URL. For Docker you should prefer the environment variable configuration method (see below).<br/> If the exporter is started with a config file argument then the config file entries have precedence over the environment variables. If a parameter is neither found in URL nor the config file nor in the environment the exporter exits with an error.<br/>
 
 ### Config File
 
@@ -72,6 +72,39 @@ SOLACE_PASSWORD=admin
 SOLACE_TIMEOUT=5s
 SOLACE_SSL_VERIFY=false
 SOLACE_REDUNDANCY=false</code></pre>
+
+### URL
+
+You can call:
+https://your_exporter:9628/solace-vpn-std?scrapeURI=https%3A%2F%2Fyour-broker%3A943&username=monitoring&password=monitoring
+
+This allows you to over write the parameters:
+- scrapeURI
+- username
+- password
+
+This provides you a single exporter for all your on prem broker.
+
+Security: Only use this feature with HTTPS.
+
+#### Sample prometheus config
+
+<pre><code>- job_name: 'solace-std'
+  scrape_interval: 15s
+  metrics_path: /solace-std
+  static_configs:
+    - targets:
+      - https://USER:PASSWORD@first-broker:943
+      - https://USER:PASSWORD@second-broker:943
+      - https://USER:PASSWORD@third-broker:943
+  relabel_configs:
+    - source_labels: [__address__]
+      target_label: __param_target
+    - source_labels: [__param_target]
+      target_label: instance
+    - target_label: __address__
+      replacement: solace-exporter:9628
+</code></pre>
 
 ## Build
 

--- a/solace_exporter.go
+++ b/solace_exporter.go
@@ -151,23 +151,23 @@ func (e *Exporter) getVersionSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	command := "<rpc><show><version/></show></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape getVersionSemp1", "err", err)
-		ch <- prometheus.MustNewConstMetric(solaceUp, prometheus.GaugeValue, -3)
-		return -3
+		level.Error(e.logger).Log("msg", "Can't scrape getVersionSemp1", "err", err, "broker", e.config.scrapeURI)
+		ch <- prometheus.MustNewConstMetric(solaceUp, prometheus.GaugeValue, 0)
+		return 0
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml getVersionSemp1", "err", err)
-		ch <- prometheus.MustNewConstMetric(solaceUp, prometheus.GaugeValue, -2)
-		return -2
+		level.Error(e.logger).Log("msg", "Can't decode Xml getVersionSemp1", "err", err, "broker", e.config.scrapeURI)
+		ch <- prometheus.MustNewConstMetric(solaceUp, prometheus.GaugeValue, 0)
+		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
-		ch <- prometheus.MustNewConstMetric(solaceUp, prometheus.GaugeValue, -1)
-		return -1
+		level.Error(e.logger).Log("msg", "Unexpected result for getVersionSemp1", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
+		ch <- prometheus.MustNewConstMetric(solaceUp, prometheus.GaugeValue, 0)
+		return 0
 	}
 
 	// remember this for the label
@@ -219,7 +219,7 @@ func (e *Exporter) getHealthSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	command := "<rpc><show><system><health/></system></show ></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape HealthSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't scrape HealthSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	defer body.Close()
@@ -227,11 +227,11 @@ func (e *Exporter) getHealthSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml HealthSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't decode Xml HealthSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
+		level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 		return 0
 	}
 
@@ -274,7 +274,7 @@ func (e *Exporter) getSpoolSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	command := "<rpc><show><message-spool></message-spool></show ></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape Solace", "err", err)
+		level.Error(e.logger).Log("msg", "Can't scrape Solace", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	defer body.Close()
@@ -282,11 +282,11 @@ func (e *Exporter) getSpoolSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml", "err", err)
+		level.Error(e.logger).Log("msg", "Can't decode Xml", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
+		level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 		return 0
 	}
 
@@ -339,7 +339,7 @@ func (e *Exporter) getRedundancySemp1(ch chan<- prometheus.Metric) (ok float64) 
 	command := "<rpc><show><redundancy/></show></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape RedundancySemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't scrape RedundancySemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	defer body.Close()
@@ -347,11 +347,11 @@ func (e *Exporter) getRedundancySemp1(ch chan<- prometheus.Metric) (ok float64) 
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml RedundancySemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't decode Xml RedundancySemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
+		level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 		return 0
 	}
 
@@ -402,7 +402,7 @@ func (e *Exporter) getConfigSyncRouterSemp1(ch chan<- prometheus.Metric) (ok flo
 	command := "<rpc><show><config-sync><database/><router/></config-sync></show></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	defer body.Close()
@@ -410,11 +410,11 @@ func (e *Exporter) getConfigSyncRouterSemp1(ch chan<- prometheus.Metric) (ok flo
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml ConfigSyncSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't decode Xml ConfigSyncSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
+		level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 		return 0
 	}
 
@@ -500,23 +500,23 @@ func (e *Exporter) getVpnSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	command := "<rpc><show><message-vpn><vpn-name>*</vpn-name></message-vpn></show></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err)
-		ch <- prometheus.MustNewConstMetric(vpnUp, prometheus.GaugeValue, -3, "")
-		return -3
+		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err, "broker", e.config.scrapeURI)
+		ch <- prometheus.MustNewConstMetric(vpnUp, prometheus.GaugeValue, 0, "")
+		return 0
 	}
 	defer body.Close()
 	decoder := xml.NewDecoder(body)
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml VpnSemp1", "err", err)
-		ch <- prometheus.MustNewConstMetric(vpnUp, prometheus.GaugeValue, -2, "")
-		return -2
+		level.Error(e.logger).Log("msg", "Can't decode Xml VpnSemp1", "err", err, "broker", e.config.scrapeURI)
+		ch <- prometheus.MustNewConstMetric(vpnUp, prometheus.GaugeValue, 0, "")
+		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
-		ch <- prometheus.MustNewConstMetric(vpnUp, prometheus.GaugeValue, -1, "")
-		return -1
+		level.Error(e.logger).Log("msg", "Unexpected result for VpnSemp1", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
+		ch <- prometheus.MustNewConstMetric(vpnUp, prometheus.GaugeValue, 0, "")
+		return 0
 	}
 
 	for _, vpn := range target.RPC.Show.MessageVpn.Vpn {
@@ -563,7 +563,7 @@ func (e *Exporter) getVpnReplicationSemp1(ch chan<- prometheus.Metric) (ok float
 	command := "<rpc><show><message-vpn><vpn-name>*</vpn-name><replication/></message-vpn></show></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	defer body.Close()
@@ -571,11 +571,11 @@ func (e *Exporter) getVpnReplicationSemp1(ch chan<- prometheus.Metric) (ok float
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml VpnSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't decode Xml VpnSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
+		level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 		return 0
 	}
 
@@ -619,7 +619,7 @@ func (e *Exporter) getConfigSyncVpnSemp1(ch chan<- prometheus.Metric) (ok float6
 	command := "<rpc><show><config-sync><database/><message-vpn/><vpn-name>*</vpn-name></config-sync></show></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	defer body.Close()
@@ -627,11 +627,11 @@ func (e *Exporter) getConfigSyncVpnSemp1(ch chan<- prometheus.Metric) (ok float6
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml ConfigSyncSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't decode Xml ConfigSyncSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
+		level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 		return 0
 	}
 
@@ -686,7 +686,7 @@ func (e *Exporter) getBridgeSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	command := "<rpc><show><bridge><bridge-name-pattern>*</bridge-name-pattern></bridge></show></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape BridgeSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't scrape BridgeSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	defer body.Close()
@@ -694,11 +694,11 @@ func (e *Exporter) getBridgeSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml BridgeSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't decode Xml BridgeSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
+		level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 		return 0
 	}
 	ch <- prometheus.MustNewConstMetric(metricsVpnStd["bridges_num_total_bridges"], prometheus.GaugeValue, target.RPC.Show.Bridge.Bridges.NumTotalBridgesValue)
@@ -838,7 +838,7 @@ func (e *Exporter) getClientStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 	for nextRequest := "<rpc><show><client><name>*</name><stats/><count/><num-elements>100</num-elements></client></show></rpc>"; nextRequest != ""; {
 		body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", nextRequest)
 		if err != nil {
-			level.Error(e.logger).Log("msg", "Can't scrape ClientSemp1", "err", err)
+			level.Error(e.logger).Log("msg", "Can't scrape ClientSemp1", "err", err, "broker", e.config.scrapeURI)
 			return 0
 		}
 		defer body.Close()
@@ -846,11 +846,11 @@ func (e *Exporter) getClientStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 		var target Data
 		err = decoder.Decode(&target)
 		if err != nil {
-			level.Error(e.logger).Log("msg", "Can't decode ClientSemp1", "err", err)
+			level.Error(e.logger).Log("msg", "Can't decode ClientSemp1", "err", err, "broker", e.config.scrapeURI)
 			return 0
 		}
 		if target.ExecuteResult.Result != "ok" {
-			level.Error(e.logger).Log("command", "Show client stats")
+			level.Error(e.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 			return 0
 		}
 
@@ -914,7 +914,7 @@ func (e *Exporter) getVpnStatsSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	command := "<rpc><show><message-vpn><vpn-name>*</vpn-name><stats/></message-vpn></show></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't scrape VpnSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	defer body.Close()
@@ -922,11 +922,11 @@ func (e *Exporter) getVpnStatsSemp1(ch chan<- prometheus.Metric) (ok float64) {
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml VpnSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't decode Xml VpnSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
+		level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 		return 0
 	}
 
@@ -1041,7 +1041,7 @@ func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 	command := "<rpc><show><bridge><bridge-name-pattern>*</bridge-name-pattern><stats/></bridge></show></rpc>"
 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", command)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape BridgeSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't scrape BridgeSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	defer body.Close()
@@ -1049,11 +1049,11 @@ func (e *Exporter) getBridgeStatsSemp1(ch chan<- prometheus.Metric) (ok float64)
 	var target Data
 	err = decoder.Decode(&target)
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode Xml BridgeSemp1", "err", err)
+		level.Error(e.logger).Log("msg", "Can't decode Xml BridgeSemp1", "err", err, "broker", e.config.scrapeURI)
 		return 0
 	}
 	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", command)
+		level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 		return 0
 	}
 	for _, bridge := range target.RPC.Show.Bridge.Bridges.Bridge {
@@ -1140,7 +1140,7 @@ func (e *Exporter) getQueueRatesSemp1(ch chan<- prometheus.Metric) (ok float64) 
 	for nextRequest := "<rpc><show><queue><name>*</name><rates/><count/><num-elements>100</num-elements></queue></show></rpc>"; nextRequest != ""; {
 		body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", nextRequest)
 		if err != nil {
-			level.Error(e.logger).Log("msg", "Can't scrape QueueRatesSemp1", "err", err)
+			level.Error(e.logger).Log("msg", "Can't scrape QueueRatesSemp1", "err", err, "broker", e.config.scrapeURI)
 			return 0
 		}
 		defer body.Close()
@@ -1148,11 +1148,11 @@ func (e *Exporter) getQueueRatesSemp1(ch chan<- prometheus.Metric) (ok float64) 
 		var target Data
 		err = decoder.Decode(&target)
 		if err != nil {
-			level.Error(e.logger).Log("msg", "Can't decode QueueRatesSemp1", "err", err)
+			level.Error(e.logger).Log("msg", "Can't decode QueueRatesSemp1", "err", err, "broker", e.config.scrapeURI)
 			return 0
 		}
 		if target.ExecuteResult.Result != "ok" {
-			level.Error(e.logger).Log("command", "Show queue rates")
+			level.Error(e.logger).Log("msg", "unexpected result", "command", nextRequest, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
 			return 0
 		}
 
@@ -1215,7 +1215,7 @@ func (e *Exporter) getQueueDetailSemp1(ch chan<- prometheus.Metric) (ok float64)
 	for nextRequest := "<rpc><show><queue><name>*</name><detail/><count/><num-elements>100</num-elements></queue></show></rpc>"; nextRequest != ""; {
 		body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", nextRequest)
 		if err != nil {
-			level.Error(e.logger).Log("msg", "Can't scrape QueueSemp1", "err", err)
+			level.Error(e.logger).Log("msg", "Can't scrape QueueDetailSemp1", "err", err, "broker", e.config.scrapeURI)
 			return 0
 		}
 		defer body.Close()
@@ -1223,11 +1223,11 @@ func (e *Exporter) getQueueDetailSemp1(ch chan<- prometheus.Metric) (ok float64)
 		var target Data
 		err = decoder.Decode(&target)
 		if err != nil {
-			level.Error(e.logger).Log("msg", "Can't decode QueueSemp1", "err", err)
+			level.Error(e.logger).Log("msg", "Can't decode QueueDetailSemp1", "err", err, "broker", e.config.scrapeURI)
 			return 0
 		}
 		if target.ExecuteResult.Result != "ok" {
-			level.Error(e.logger).Log("command", "Show queue details")
+			level.Error(e.logger).Log("msg", "Can't scrape QueueDetailSemp1", "err", err, "broker", e.config.scrapeURI)
 			return 0
 		}
 
@@ -1246,29 +1246,29 @@ func (e *Exporter) getQueueDetailSemp1(ch chan<- prometheus.Metric) (ok float64)
 	return 1
 }
 
-func performRequest(e Exporter, target *struct {
-	ExecuteResult struct {
-		Result string `xml:"code,attr"`
-	} `xml:"execute-result"`
-}, nextRequest string) (result int) {
-	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", nextRequest)
-	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't scrape QueueRatesSemp1", "err", err)
-		return 0
-	}
-	defer body.Close()
-	decoder := xml.NewDecoder(body)
-	err = decoder.Decode(&target)
-	if err != nil {
-		level.Error(e.logger).Log("msg", "Can't decode QueueRatesSemp1", "err", err)
-		return 0
-	}
-	if target.ExecuteResult.Result != "ok" {
-		level.Error(e.logger).Log("command", "Show queue rates")
-		return 0
-	}
-	return 1
-}
+// func performRequest(e Exporter, target *struct {
+// 	ExecuteResult struct {
+// 		Result string `xml:"code,attr"`
+// 	} `xml:"execute-result"`
+// }, nextRequest string) (result int) {
+// 	body, err := e.postHTTP(e.config.scrapeURI+"/SEMP", "application/xml", nextRequest)
+// 	if err != nil {
+// 		level.Error(e.logger).Log("msg", "Can't scrape QueueRatesSemp1", "err", err, "broker", e.config.scrapeURI)
+// 		return 0
+// 	}
+// 	defer body.Close()
+// 	decoder := xml.NewDecoder(body)
+// 	err = decoder.Decode(&target)
+// 	if err != nil {
+// 		level.Error(e.logger).Log("msg", "Can't decode QueueRatesSemp1", "err", err, "broker", e.config.scrapeURI)
+// 		return 0
+// 	}
+// 	if target.ExecuteResult.Result != "ok" {
+// 		level.Error(e.logger).Log("msg", "unexpected result", "command", command, "result", target.ExecuteResult.Result, "broker", e.config.scrapeURI)
+// 		return 0
+// 	}
+// 	return 1
+// }
 
 // Encodes string to 0,1,2,... metric
 func encodeMetricMulti(item string, refItems []string) float64 {


### PR DESCRIPTION
### Add Feature:

You can call:
https://your_exporter:9628/solace-vpn-std?scrapeURI=https%3A%2F%2Fyour-broker%3A943&username=monitoring&password=monitoring

This allows you to over write the parameters:
- scrapeURI
- username
- password

This provides you a single exporter for all your on prem broker.

Security: Only use this feature with HTTPS.

#### Sample prometheus config

<pre><code>- job_name: 'solace-std'
  scrape_interval: 15s
  metrics_path: /solace-std
  static_configs:
    - targets:
      - https://USER:PASSWORD@first-broker:943
      - https://USER:PASSWORD@second-broker:943
      - https://USER:PASSWORD@third-broker:943
  relabel_configs:
    - source_labels: [__address__]
      target_label: __param_target
    - source_labels: [__param_target]
      target_label: instance
    - target_label: __address__
      replacement: solace-exporter:9628
</code></pre>

### Code refactoring

we didt also as a refactoring to make the code better readable, but this makes this pull request hard to read. Sorry for that.

### Backword compatibility

This change dosent harm any of the current functionalety.